### PR TITLE
Add TMPro imports to screen controllers

### DIFF
--- a/Scripts/Screens/EliminationScreenController.cs
+++ b/Scripts/Screens/EliminationScreenController.cs
@@ -3,6 +3,7 @@ using UnityEngine.UI;
 using UnityEngine.SceneManagement;
 using System.Collections.Generic;
 using DG.Tweening;
+using TMPro;
 using RobotsGame.Core;
 using RobotsGame.Data;
 using RobotsGame.Managers;

--- a/Scripts/Screens/QuestionScreenController.cs
+++ b/Scripts/Screens/QuestionScreenController.cs
@@ -3,6 +3,7 @@ using UnityEngine.UI;
 using UnityEngine.SceneManagement;
 using System.Collections.Generic;
 using DG.Tweening;
+using TMPro;
 using RobotsGame.Core;
 using RobotsGame.Data;
 using RobotsGame.Managers;

--- a/Scripts/Screens/VotingScreenController.cs
+++ b/Scripts/Screens/VotingScreenController.cs
@@ -3,6 +3,7 @@ using UnityEngine.UI;
 using UnityEngine.SceneManagement;
 using System.Collections.Generic;
 using DG.Tweening;
+using TMPro;
 using RobotsGame.Core;
 using RobotsGame.Data;
 using RobotsGame.Managers;


### PR DESCRIPTION
## Summary
- add TMPro namespace to question, elimination, and voting screen controllers so TextMeshPro fields compile

## Testing
- not run (Unity editor required)

------
https://chatgpt.com/codex/tasks/task_e_68dde4f024bc832ea2bd033a65f4af47