### PR TITLE
Preserve server scores in player updates

### DIFF
--- a/Scripts/Data/Player.cs
+++ b/Scripts/Data/Player.cs
@@ -28,6 +28,14 @@ namespace RobotsGame.Data
             this.isDesktop = isDesktop;
         }
 
+        public Player(string playerName, string icon, int score, bool isDesktop = false)
+        {
+            this.playerName = playerName;
+            this.icon = icon;
+            this.score = score;
+            this.isDesktop = isDesktop;
+        }
+
         public void AddScore(int points)
         {
             score += points;

--- a/Scripts/Managers/GameManager.cs
+++ b/Scripts/Managers/GameManager.cs
@@ -402,7 +402,7 @@ namespace RobotsGame.Managers
             players.Clear();
             foreach (var playerData in data.players)
             {
-                players.Add(new Player(playerData.name, playerData.icon));
+                players.Add(new Player(playerData.name, playerData.icon, playerData.score));
             }
 
             Debug.Log($"Players updated: {players.Count} players");


### PR DESCRIPTION
## Summary
- add a Player constructor that accepts an initial score from the server
- ensure GameManager.HandlePlayersUpdate hydrates each Player with the score from player update messages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dde51abb18832e92678d4cd0a12a5c