### PR TITLE
Filter eliminated answers on voting screen

### DIFF
--- a/Scripts/Screens/VotingScreenController.cs
+++ b/Scripts/Screens/VotingScreenController.cs
@@ -74,8 +74,24 @@ namespace RobotsGame.Screens
             currentQuestion = GameManager.Instance.CurrentQuestion;
 
             // Get remaining answers (after elimination)
-            // For now, use all current answers (real game would filter eliminated)
-            remainingAnswers = new List<Answer>(GameManager.Instance.CurrentAnswers);
+            var allAnswers = GameManager.Instance.CurrentAnswers;
+            var eliminatedAnswers = currentQuestion != null ? currentQuestion.EliminatedAnswers : null;
+
+            if (eliminatedAnswers != null && eliminatedAnswers.Count > 0)
+            {
+                remainingAnswers = new List<Answer>();
+                foreach (var answer in allAnswers)
+                {
+                    if (!eliminatedAnswers.Contains(answer.Text))
+                    {
+                        remainingAnswers.Add(answer);
+                    }
+                }
+            }
+            else
+            {
+                remainingAnswers = new List<Answer>(allAnswers);
+            }
 
             // Get local player
             localPlayer = GameManager.Instance.Players.Count > 0


### PR DESCRIPTION
## Summary
- filter voting screen answer list to exclude eliminated responses when building remaining options
- preserve full list when no elimination occurred so tie and untouched rounds continue to work

## Testing
- Not run (Unity project / no automated tests available)


------
https://chatgpt.com/codex/tasks/task_e_68dde51998a0832ea9b8bf5c5d89e774