### PR TITLE
Prevent duplicate special answers across transitions

### DIFF
--- a/Scripts/Managers/GameManager.cs
+++ b/Scripts/Managers/GameManager.cs
@@ -228,19 +228,53 @@ namespace RobotsGame.Managers
         {
             if (currentQuestion == null) return;
 
-            // Add correct answer
-            currentAnswers.Add(new Answer(
-                currentQuestion.CorrectAnswer,
-                GameConstants.AnswerType.Correct,
-                "System"
-            ));
+            bool hasCorrectAnswer = false;
+            bool hasRobotAnswer = false;
 
-            // Add robot answer
-            currentAnswers.Add(new Answer(
-                currentQuestion.RobotAnswer,
-                GameConstants.AnswerType.Robot,
-                "Robot"
-            ));
+            foreach (var answer in currentAnswers)
+            {
+                if (answer.Type == GameConstants.AnswerType.Correct)
+                {
+                    hasCorrectAnswer = true;
+                }
+                else if (answer.Type == GameConstants.AnswerType.Robot)
+                {
+                    hasRobotAnswer = true;
+                }
+
+                if (hasCorrectAnswer && hasRobotAnswer)
+                {
+                    break;
+                }
+            }
+
+            if (!hasCorrectAnswer)
+            {
+                currentAnswers.Add(new Answer(
+                    currentQuestion.CorrectAnswer,
+                    GameConstants.AnswerType.Correct,
+                    "System"
+                ));
+            }
+
+            if (!hasRobotAnswer)
+            {
+                currentAnswers.Add(new Answer(
+                    currentQuestion.RobotAnswer,
+                    GameConstants.AnswerType.Robot,
+                    "Robot"
+                ));
+            }
+
+            int expectedAnswerCount = players.Count + 2; // Players + correct + robot
+            if (currentAnswers.Count != expectedAnswerCount)
+            {
+                Debug.LogWarning($"CurrentAnswers count mismatch. Expected {expectedAnswerCount}, actual {currentAnswers.Count}.");
+            }
+            else
+            {
+                Debug.Log($"CurrentAnswers contains {currentAnswers.Count} entries ({players.Count} players + 2 special answers).");
+            }
         }
 
         public List<Answer> GetShuffledAnswers()

--- a/Scripts/Screens/EliminationScreenController.cs
+++ b/Scripts/Screens/EliminationScreenController.cs
@@ -74,6 +74,8 @@ namespace RobotsGame.Screens
             // Get answers from GameManager
             allAnswers = GameManager.Instance.CurrentAnswers;
 
+            ValidateAnswerDisplaySet("EliminationScreen", allAnswers);
+
             // Get local player (simplified - in real game would get from session)
             localPlayer = GameManager.Instance.Players.Count > 0
                 ? GameManager.Instance.Players[0]
@@ -111,6 +113,47 @@ namespace RobotsGame.Screens
 
             // Fade in
             FadeTransition.Instance.FadeIn(0.5f);
+        }
+
+        private void ValidateAnswerDisplaySet(string context, List<Answer> answers)
+        {
+            if (answers == null) return;
+
+            HashSet<string> uniqueKeys = new HashSet<string>();
+            bool hasDuplicate = false;
+            bool hasCorrectAnswer = false;
+            bool hasRobotAnswer = false;
+
+            foreach (var answer in answers)
+            {
+                if (answer == null) continue;
+
+                string key = $"{answer.Type}|{answer.PlayerName}|{answer.Text}";
+                if (!uniqueKeys.Add(key))
+                {
+                    hasDuplicate = true;
+                    Debug.LogWarning($"{context}: Duplicate answer entry detected for {key}.");
+                }
+
+                if (answer.Type == GameConstants.AnswerType.Correct)
+                {
+                    if (hasCorrectAnswer)
+                    {
+                        Debug.LogWarning($"{context}: Multiple correct answers detected.");
+                    }
+                    hasCorrectAnswer = true;
+                }
+                else if (answer.Type == GameConstants.AnswerType.Robot)
+                {
+                    if (hasRobotAnswer)
+                    {
+                        Debug.LogWarning($"{context}: Multiple robot answers detected.");
+                    }
+                    hasRobotAnswer = true;
+                }
+            }
+
+            Debug.Log($"{context}: Prepared {answers.Count} answers for display. Correct present: {hasCorrectAnswer}, Robot present: {hasRobotAnswer}, Duplicates found: {hasDuplicate}.");
         }
 
         private void Update()

--- a/Scripts/Screens/QuestionScreenController.cs
+++ b/Scripts/Screens/QuestionScreenController.cs
@@ -53,6 +53,7 @@ namespace RobotsGame.Screens
         private bool allAnswersReceived = false;
         private bool hasPlayedQuestionIntroVO = false;
         private bool hasPlayedNudgeVO = false;
+        private bool hasInjectedSpecialAnswers = false;
 
         // ===========================
         // LIFECYCLE
@@ -514,8 +515,15 @@ namespace RobotsGame.Screens
 
         private void TransitionToNextScreen()
         {
-            // Add robot and correct answers to GameManager
-            GameManager.Instance.AddRobotAndCorrectAnswers();
+            if (!hasInjectedSpecialAnswers)
+            {
+                GameManager.Instance.AddRobotAndCorrectAnswers();
+                hasInjectedSpecialAnswers = true;
+            }
+            else
+            {
+                Debug.LogWarning("Special answers already injected for this round. Skipping duplicate insertion.");
+            }
 
             FadeTransition.Instance.FadeOut(1f, () =>
             {

--- a/Scripts/Screens/VotingScreenController.cs
+++ b/Scripts/Screens/VotingScreenController.cs
@@ -76,6 +76,7 @@ namespace RobotsGame.Screens
             // Get remaining answers (after elimination)
             // For now, use all current answers (real game would filter eliminated)
             remainingAnswers = new List<Answer>(GameManager.Instance.CurrentAnswers);
+            ValidateAnswerDisplaySet("VotingScreen", remainingAnswers);
 
             // Get local player
             localPlayer = GameManager.Instance.Players.Count > 0
@@ -114,6 +115,47 @@ namespace RobotsGame.Screens
 
             // Fade in
             FadeTransition.Instance.FadeIn(0.5f);
+        }
+
+        private void ValidateAnswerDisplaySet(string context, List<Answer> answers)
+        {
+            if (answers == null) return;
+
+            HashSet<string> uniqueKeys = new HashSet<string>();
+            bool hasDuplicate = false;
+            bool hasCorrectAnswer = false;
+            bool hasRobotAnswer = false;
+
+            foreach (var answer in answers)
+            {
+                if (answer == null) continue;
+
+                string key = $"{answer.Type}|{answer.PlayerName}|{answer.Text}";
+                if (!uniqueKeys.Add(key))
+                {
+                    hasDuplicate = true;
+                    Debug.LogWarning($"{context}: Duplicate answer entry detected for {key}.");
+                }
+
+                if (answer.Type == GameConstants.AnswerType.Correct)
+                {
+                    if (hasCorrectAnswer)
+                    {
+                        Debug.LogWarning($"{context}: Multiple correct answers detected.");
+                    }
+                    hasCorrectAnswer = true;
+                }
+                else if (answer.Type == GameConstants.AnswerType.Robot)
+                {
+                    if (hasRobotAnswer)
+                    {
+                        Debug.LogWarning($"{context}: Multiple robot answers detected.");
+                    }
+                    hasRobotAnswer = true;
+                }
+            }
+
+            Debug.Log($"{context}: Prepared {answers.Count} answers for display. Correct present: {hasCorrectAnswer}, Robot present: {hasRobotAnswer}, Duplicates found: {hasDuplicate}.");
         }
 
         private void Update()


### PR DESCRIPTION
## Summary
- ensure `GameManager.AddRobotAndCorrectAnswers` skips adding duplicate robot/correct entries and logs the final answer count
- guard `QuestionScreenController` against injecting special answers multiple times across callbacks
- add diagnostics on elimination and voting screens to confirm each answer is presented once

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68dde514c5c8832e9724e053d087a77d