### PR TITLE
Handle banned words from JS data

### DIFF
--- a/Scripts/Tests/EditMode/AnswerValidatorBannedWordsTests.cs
+++ b/Scripts/Tests/EditMode/AnswerValidatorBannedWordsTests.cs
@@ -1,0 +1,26 @@
+using NUnit.Framework;
+using RobotsGame.Core;
+
+namespace RobotsGame.Tests
+{
+    public class AnswerValidatorBannedWordsTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            AnswerValidator.ReloadBannedWords();
+        }
+
+        [Test]
+        public void ContainsProfanity_LoadsWordsFromDataFile()
+        {
+            Assert.IsTrue(AnswerValidator.ContainsProfanity("Please kill yourself."));
+        }
+
+        [Test]
+        public void ContainsProfanity_IgnoresSafeText()
+        {
+            Assert.IsFalse(AnswerValidator.ContainsProfanity("Hello friends"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- update AnswerValidator to normalize profanity checks and load banned words from JS/JSON or text files
- add structured content parsing and path lookup so the profanity list populates at runtime
- create an edit mode test that reloads the banned words and verifies detection of profane and safe input

## Testing
- not run (Unity editor tests required)


------
https://chatgpt.com/codex/tasks/task_e_68dde4eea6ec832eb398822225b63224