### PR TITLE
Add missing UnityEngine.UI using to ResponsiveUI

### DIFF
--- a/Scripts/UI/Utilities/ResponsiveUI.cs
+++ b/Scripts/UI/Utilities/ResponsiveUI.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.UI;
 using RobotsGame.Core;
 
 namespace RobotsGame.UI.Utilities


### PR DESCRIPTION
## Summary
- add the UnityEngine.UI namespace import required for CanvasScaler in ResponsiveUI

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dde5ead61c832e931ec7bc8f763bbe