### PR TITLE
Ensure player icon setup uses child sprite image

### DIFF
--- a/Scripts/UI/PlayerIconGrid.cs
+++ b/Scripts/UI/PlayerIconGrid.cs
@@ -169,8 +169,29 @@ namespace RobotsGame.UI
 
         private void SetupPlayerIcon(GameObject iconObj, Player player)
         {
-            // Find icon image component
-            Image iconImage = iconObj.GetComponentInChildren<Image>();
+            // Find icon image component (prefer dedicated child named "Icon")
+            Image iconImage = null;
+
+            Transform iconTransform = iconObj.transform.Find("Icon");
+            if (iconTransform != null)
+            {
+                iconImage = iconTransform.GetComponent<Image>();
+            }
+
+            if (iconImage == null)
+            {
+                // Fallback: find first child image that isn't the background on the root object
+                Image[] images = iconObj.GetComponentsInChildren<Image>(includeInactive: true);
+                foreach (var image in images)
+                {
+                    if (image.gameObject != iconObj)
+                    {
+                        iconImage = image;
+                        break;
+                    }
+                }
+            }
+
             if (iconImage != null)
             {
                 // Load player icon sprite


### PR DESCRIPTION
## Summary
- update player icon setup to target the dedicated child image before assigning sprites
- fall back to the first non-root image so the background tint remains untouched when using the default template

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dde5ef8590832eb5896b75a475dc53