### PR TITLE
Handle deferred question initialization

### DIFF
--- a/Scripts/Screens/QuestionScreenController.cs
+++ b/Scripts/Screens/QuestionScreenController.cs
@@ -48,6 +48,7 @@ namespace RobotsGame.Screens
         private HashSet<string> submittedPlayerNames = new HashSet<string>();
         private bool hasLocalPlayerSubmitted = false;
         private string localPlayerAnswer = "";
+        private bool hasInitializedQuestion = false;
 
         // State tracking
         private bool allAnswersReceived = false;
@@ -70,17 +71,7 @@ namespace RobotsGame.Screens
 
         private void Start()
         {
-            // Get current question from GameManager
-            currentQuestion = GameManager.Instance.CurrentQuestion;
-
-            if (currentQuestion != null)
-            {
-                SetupQuestion(currentQuestion);
-            }
-            else
-            {
-                Debug.LogError("No question loaded in GameManager!");
-            }
+            DisableAnswerUI();
 
             // Setup answer validation callbacks
             if (mobileInput != null)
@@ -95,30 +86,12 @@ namespace RobotsGame.Screens
                 SubscribeToNetworkEvents();
             }
 
-            // Start timer
-            if (isDesktop && timerDisplay != null)
+            // Get current question from GameManager
+            if (!TryInitializeQuestion())
             {
-                timerDisplay.StartTimer();
-                timerDisplay.OnTimerExpired += HandleTimerExpired;
+                Debug.LogWarning("Waiting for question data from GameManager before initializing QuestionScreen.");
+                return;
             }
-            else if (!isDesktop && timerDisplayMobile != null)
-            {
-                timerDisplayMobile.StartTimer(0f); // Immediate start on mobile
-                timerDisplayMobile.OnTimerExpired += HandleTimerExpired;
-            }
-
-            // Play question intro VO (desktop only)
-            if (isDesktop && !hasPlayedQuestionIntroVO)
-            {
-                DOVirtual.DelayedCall(GameConstants.Delays.QuestionIntroDelay, () =>
-                {
-                    AudioManager.Instance.PlayVoiceOver(GameConstants.Audio.VO_QuestionIntro);
-                    hasPlayedQuestionIntroVO = true;
-                });
-            }
-
-            // Fade in from black
-            FadeTransition.Instance.FadeIn(1f);
         }
 
         private void OnDestroy()
@@ -210,6 +183,14 @@ namespace RobotsGame.Screens
 
         private void Update()
         {
+            if (!hasInitializedQuestion)
+            {
+                if (!TryInitializeQuestion())
+                {
+                    return;
+                }
+            }
+
             // Check timer expiration
             TimerDisplay activeTimer = isDesktop ? timerDisplay : timerDisplayMobile;
             if (activeTimer != null && activeTimer.IsExpired && !hasLocalPlayerSubmitted)
@@ -266,6 +247,82 @@ namespace RobotsGame.Screens
             allAnswers.Add(new Answer(question.RobotAnswer, GameConstants.AnswerType.Robot, "Robot"));
         }
 
+        private bool TryInitializeQuestion()
+        {
+            if (hasInitializedQuestion)
+                return true;
+
+            if (GameManager.Instance == null)
+                return false;
+
+            Question managerQuestion = GameManager.Instance.CurrentQuestion;
+            if (managerQuestion == null)
+                return false;
+
+            currentQuestion = managerQuestion;
+
+            EnableAnswerUI();
+            SetupQuestion(currentQuestion);
+            InitializeQuestionFlow();
+
+            hasInitializedQuestion = true;
+            return true;
+        }
+
+        private void InitializeQuestionFlow()
+        {
+            if (currentQuestion == null)
+                return;
+
+            // Start timer
+            if (isDesktop && timerDisplay != null)
+            {
+                timerDisplay.StartTimer();
+                timerDisplay.OnTimerExpired += HandleTimerExpired;
+            }
+            else if (!isDesktop && timerDisplayMobile != null)
+            {
+                timerDisplayMobile.StartTimer(0f); // Immediate start on mobile
+                timerDisplayMobile.OnTimerExpired += HandleTimerExpired;
+            }
+
+            // Play question intro VO (desktop only)
+            if (isDesktop && !hasPlayedQuestionIntroVO)
+            {
+                DOVirtual.DelayedCall(GameConstants.Delays.QuestionIntroDelay, () =>
+                {
+                    AudioManager.Instance.PlayVoiceOver(GameConstants.Audio.VO_QuestionIntro);
+                    hasPlayedQuestionIntroVO = true;
+                });
+            }
+
+            // Fade in from black
+            FadeTransition.Instance.FadeIn(1f);
+        }
+
+        private void DisableAnswerUI()
+        {
+            if (desktopContent != null)
+                desktopContent.SetActive(false);
+
+            if (mobileInput != null)
+            {
+                mobileInput.gameObject.SetActive(false);
+                mobileInput.SetEnabled(false);
+            }
+        }
+
+        private void EnableAnswerUI()
+        {
+            SetupPlatformContent();
+
+            if (!isDesktop && mobileInput != null)
+            {
+                mobileInput.gameObject.SetActive(true);
+                mobileInput.SetEnabled(true);
+            }
+        }
+
         private void SetupDesktop(Question question, int round)
         {
             // Set background
@@ -316,6 +373,9 @@ namespace RobotsGame.Screens
 
         private void ValidateAnswerRealTime(string answer)
         {
+            if (currentQuestion == null)
+                return;
+
             if (string.IsNullOrEmpty(answer))
                 return;
 
@@ -412,6 +472,9 @@ namespace RobotsGame.Screens
 
         private bool ValidateAnswerForSubmission(string answer)
         {
+            if (currentQuestion == null)
+                return false;
+
             // Check correct answer
             if (AnswerValidator.IsCorrectAnswer(answer, currentQuestion.CorrectAnswer))
             {
@@ -444,6 +507,9 @@ namespace RobotsGame.Screens
 
         private void AutoSubmitAnswer()
         {
+            if (currentQuestion == null)
+                return;
+
             string answer = isDesktop ? "" : (mobileInput != null ? mobileInput.CurrentAnswer : "");
 
             if (string.IsNullOrEmpty(answer))


### PR DESCRIPTION
## Summary
- wait for the current question to become available before initializing the Question screen
- gate update/validation logic and auto-submit flows until the question data is present
- disable the answer UI until the question loads, then restore it when the setup completes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dde5275c20832e9e24f04ae37aadb2