### PR TITLE
Ensure controllers use stored local player identity

### DIFF
--- a/Scripts/Managers/GameManager.cs
+++ b/Scripts/Managers/GameManager.cs
@@ -48,6 +48,9 @@ namespace RobotsGame.Managers
         [SerializeField] private Dictionary<string, string> playerFinalVotes = new Dictionary<string, string>();
         [SerializeField] private VoteResults eliminationResults;
         [SerializeField] private VoteResults votingResults;
+        [SerializeField] private string localPlayerName;
+        [SerializeField] private string localPlayerIcon;
+        private Player localFallbackPlayer;
 
         // ===========================
         // PROPERTIES
@@ -62,6 +65,9 @@ namespace RobotsGame.Managers
         public List<Answer> CurrentAnswers => currentAnswers;
         public int TotalRounds => (int)gameMode;
         public string RoomCode => roomCode;
+        public string LocalPlayerName => localPlayerName;
+        public string LocalPlayerIcon => localPlayerIcon;
+        public Player LocalPlayer => GetLocalPlayer();
 
         // ===========================
         // LIFECYCLE
@@ -162,6 +168,52 @@ namespace RobotsGame.Managers
         public Player GetPlayer(string playerName)
         {
             return players.Find(p => p.PlayerName == playerName);
+        }
+
+        public void SetLocalPlayerIdentity(string playerName, string playerIcon)
+        {
+            localPlayerName = playerName;
+            localPlayerIcon = playerIcon;
+
+            if (!string.IsNullOrEmpty(localPlayerName))
+            {
+                localFallbackPlayer = new Player(localPlayerName, string.IsNullOrEmpty(localPlayerIcon) ? "icon1" : localPlayerIcon);
+            }
+            else
+            {
+                localFallbackPlayer = null;
+            }
+        }
+
+        public Player GetLocalPlayer()
+        {
+            if (!string.IsNullOrEmpty(localPlayerName))
+            {
+                var existingPlayer = players.Find(p => p.PlayerName == localPlayerName);
+                if (existingPlayer != null)
+                {
+                    return existingPlayer;
+                }
+
+                if (localFallbackPlayer == null || localFallbackPlayer.PlayerName != localPlayerName)
+                {
+                    localFallbackPlayer = new Player(localPlayerName, string.IsNullOrEmpty(localPlayerIcon) ? "icon1" : localPlayerIcon);
+                }
+
+                return localFallbackPlayer;
+            }
+
+            if (players.Count > 0)
+            {
+                return players[0];
+            }
+
+            if (localFallbackPlayer == null)
+            {
+                localFallbackPlayer = new Player("Player 1", "icon1");
+            }
+
+            return localFallbackPlayer;
         }
 
         // ===========================
@@ -403,6 +455,16 @@ namespace RobotsGame.Managers
             foreach (var playerData in data.players)
             {
                 players.Add(new Player(playerData.name, playerData.icon));
+            }
+
+            if (!string.IsNullOrEmpty(localPlayerName))
+            {
+                var local = players.Find(p => p.PlayerName == localPlayerName);
+                if (local != null)
+                {
+                    localPlayerIcon = local.Icon;
+                    localFallbackPlayer = local;
+                }
             }
 
             Debug.Log($"Players updated: {players.Count} players");

--- a/Scripts/Network/NetworkManager.cs
+++ b/Scripts/Network/NetworkManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 using RobotsGame.Data;
+using RobotsGame.Managers;
 
 namespace RobotsGame.Network
 {
@@ -148,6 +149,7 @@ namespace RobotsGame.Network
             isHost = true;
             this.playerName = playerName;
             this.playerIcon = playerIcon;
+            GameManager.Instance?.SetLocalPlayerIdentity(playerName, playerIcon);
 
             var data = new
             {
@@ -175,6 +177,7 @@ namespace RobotsGame.Network
             this.roomCode = roomCode;
             this.playerName = playerName;
             this.playerIcon = playerIcon;
+            GameManager.Instance?.SetLocalPlayerIdentity(playerName, playerIcon);
 
             var data = new
             {

--- a/Scripts/Screens/EliminationScreenController.cs
+++ b/Scripts/Screens/EliminationScreenController.cs
@@ -74,10 +74,8 @@ namespace RobotsGame.Screens
             // Get answers from GameManager
             allAnswers = GameManager.Instance.CurrentAnswers;
 
-            // Get local player (simplified - in real game would get from session)
-            localPlayer = GameManager.Instance.Players.Count > 0
-                ? GameManager.Instance.Players[0]
-                : new Player("Player 1", "icon1");
+            // Get local player identity from GameManager
+            localPlayer = GameManager.Instance.GetLocalPlayer();
 
             // Find player's answer
             string playerAnswer = "";

--- a/Scripts/Screens/FinalResultsController.cs
+++ b/Scripts/Screens/FinalResultsController.cs
@@ -73,10 +73,8 @@ namespace RobotsGame.Screens
             // Get ranked players
             rankedPlayers = GameManager.Instance.GetRankedPlayers();
 
-            // Get local player
-            localPlayer = GameManager.Instance.Players.Count > 0
-                ? GameManager.Instance.Players[0]
-                : new Player("Player 1", "icon1");
+            // Get local player identity from GameManager
+            localPlayer = GameManager.Instance.GetLocalPlayer();
 
             if (isDesktop)
             {

--- a/Scripts/Screens/QuestionScreenController.cs
+++ b/Scripts/Screens/QuestionScreenController.cs
@@ -365,10 +365,8 @@ namespace RobotsGame.Screens
             if (!ValidateAnswerForSubmission(answer))
                 return;
 
-            // Get local player (simplified - in real game would get from session)
-            Player localPlayer = GameManager.Instance.Players.Count > 0
-                ? GameManager.Instance.Players[0]
-                : new Player("Player 1", "icon1");
+            // Get local player identity from GameManager
+            Player localPlayer = GameManager.Instance.GetLocalPlayer();
 
             // Create answer object
             Answer playerAnswer = new Answer(answer, GameConstants.AnswerType.Player, localPlayer.PlayerName);

--- a/Scripts/Screens/VotingScreenController.cs
+++ b/Scripts/Screens/VotingScreenController.cs
@@ -77,10 +77,8 @@ namespace RobotsGame.Screens
             // For now, use all current answers (real game would filter eliminated)
             remainingAnswers = new List<Answer>(GameManager.Instance.CurrentAnswers);
 
-            // Get local player
-            localPlayer = GameManager.Instance.Players.Count > 0
-                ? GameManager.Instance.Players[0]
-                : new Player("Player 1", "icon1");
+            // Get local player identity from GameManager
+            localPlayer = GameManager.Instance.GetLocalPlayer();
 
             // Find player's answer
             string playerAnswer = "";


### PR DESCRIPTION
## Summary
- store the local player's name and icon in `GameManager` with a safe accessor
- update `NetworkManager` to set the local identity when creating or joining rooms
- refresh question, elimination, voting, and final results screens to pull the local player from `GameManager`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dde4ef1560832e9577ab3b72ea78ea