### PR TITLE
Add TMPro namespace to screen controllers

### DIFF
--- a/Scripts/Screens/EliminationScreenController.cs
+++ b/Scripts/Screens/EliminationScreenController.cs
@@ -1,9 +1,9 @@
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.SceneManagement;
 using System.Collections.Generic;
 using DG.Tweening;
-using TMPro;
 using RobotsGame.Core;
 using RobotsGame.Data;
 using RobotsGame.Managers;

--- a/Scripts/Screens/QuestionScreenController.cs
+++ b/Scripts/Screens/QuestionScreenController.cs
@@ -1,10 +1,9 @@
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
-using TMPro;
 using UnityEngine.SceneManagement;
 using System.Collections.Generic;
 using DG.Tweening;
-using TMPro;
 using RobotsGame.Core;
 using RobotsGame.Data;
 using RobotsGame.Managers;

--- a/Scripts/Screens/VotingScreenController.cs
+++ b/Scripts/Screens/VotingScreenController.cs
@@ -1,9 +1,9 @@
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.SceneManagement;
 using System.Collections.Generic;
 using DG.Tweening;
-using TMPro;
 using RobotsGame.Core;
 using RobotsGame.Data;
 using RobotsGame.Managers;


### PR DESCRIPTION
## Summary
- ensure the Question, Voting, and Elimination screen controllers import the TMPro namespace at the top of their using blocks so TextMeshPro references resolve

## Testing
- not run (Unity build tooling is not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dde5fafcf8832e968a495cc1d0d580