### PR TITLE
Add missing Unity UI namespace to ResponsiveUI

### DIFF
--- a/Scripts/UI/Utilities/ResponsiveUI.cs
+++ b/Scripts/UI/Utilities/ResponsiveUI.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.UI;
 using RobotsGame.Core;
 
 namespace RobotsGame.UI.Utilities


### PR DESCRIPTION
## Summary
- add the UnityEngine.UI namespace import to ResponsiveUI so CanvasScaler and related UI types resolve

## Testing
- not run (Unity build environment not available in this container)


------
https://chatgpt.com/codex/tasks/task_e_68dde5fbd75c832eb8ea292cf0a2829b