### PR TITLE
Restore scene transition from results screen

### DIFF
--- a/Scripts/Screens/ResultsScreenController.cs
+++ b/Scripts/Screens/ResultsScreenController.cs
@@ -531,13 +531,7 @@ namespace RobotsGame.Screens
             FadeTransition.Instance.FadeOut(0.5f, () =>
             {
                 Debug.Log($"Transitioning to {targetScene}");
-                // SceneManager.LoadScene(targetScene);
-
-                // Temporary: fade back in
-                DOVirtual.DelayedCall(0.5f, () =>
-                {
-                    FadeTransition.Instance.FadeIn(1f);
-                });
+                SceneManager.LoadScene(targetScene);
             });
         }
 


### PR DESCRIPTION
## Summary
- restore the next-round button to load the configured scene after the fade-out completes
- ensure the button still targets the next question during mid-game and the final results screen on the last round

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dde84b1ef0832e9bdbc2bb0d874f64