### PR TITLE
Fix elimination screen transition to voting phase

### DIFF
--- a/Scripts/Screens/EliminationScreenController.cs
+++ b/Scripts/Screens/EliminationScreenController.cs
@@ -434,13 +434,7 @@ namespace RobotsGame.Screens
             FadeTransition.Instance.FadeOut(0.5f, () =>
             {
                 Debug.Log($"Transitioning to {nextSceneName}");
-                // SceneManager.LoadScene(nextSceneName);
-
-                // Temporary: fade back in
-                DOVirtual.DelayedCall(0.5f, () =>
-                {
-                    FadeTransition.Instance.FadeIn(1f);
-                });
+                SceneManager.LoadScene(nextSceneName);
             });
         }
 


### PR DESCRIPTION
## Summary
- restore the scene load after the elimination fade-out so the voting screen is reached
- remove the temporary fade-in block now that the transition is live again

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dde8428e9c832eb20b9fcf48a27217