### PR TITLE
Ensure single-player elimination tracks eliminated answer

### DIFF
--- a/Scripts/Screens/EliminationScreenController.cs
+++ b/Scripts/Screens/EliminationScreenController.cs
@@ -324,13 +324,29 @@ namespace RobotsGame.Screens
             // For now, just eliminate the selected answer
             votingResults.CalculateElimination();
 
+            TrackEliminatedAnswer();
+
             // If no elimination calculated (because only one vote), set it
             if (votingResults.EliminatedAnswer == null && !votingResults.TieOccurred)
             {
                 // Simulate that our vote was enough
                 votingResults.AddVote(selectedAnswer);
                 votingResults.CalculateElimination();
+
+                TrackEliminatedAnswer();
             }
+        }
+
+        private void TrackEliminatedAnswer()
+        {
+            if (votingResults == null || votingResults.TieOccurred)
+                return;
+
+            string eliminatedAnswer = votingResults.EliminatedAnswer;
+            if (string.IsNullOrEmpty(eliminatedAnswer))
+                return;
+
+            GameManager.Instance.CurrentQuestion?.AddEliminatedAnswer(eliminatedAnswer);
         }
 
         // ===========================


### PR DESCRIPTION
## Summary
- update the single-player elimination flow to record the eliminated answer on the current question
- add a helper that guards against ties and missing answers before tracking eliminations

## Testing
- not run (Unity Editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dde8452438832e9e379e32be652ff7