### PR TITLE
Add timer expiry event for question screen

### DIFF
--- a/Scripts/Screens/QuestionScreenController.cs
+++ b/Scripts/Screens/QuestionScreenController.cs
@@ -112,10 +112,10 @@ namespace RobotsGame.Screens
 
             // Unsubscribe from timer events
             if (timerDisplay != null)
-                timerDisplay.OnTimerExpired -= HandleTimerExpired;
+                timerDisplay.TimerExpired -= HandleTimerExpired;
 
             if (timerDisplayMobile != null)
-                timerDisplayMobile.OnTimerExpired -= HandleTimerExpired;
+                timerDisplayMobile.TimerExpired -= HandleTimerExpired;
 
             // Kill DOTween animations
             DOTween.Kill(this);
@@ -279,12 +279,12 @@ namespace RobotsGame.Screens
             if (isDesktop && timerDisplay != null)
             {
                 timerDisplay.StartTimer();
-                timerDisplay.OnTimerExpired += HandleTimerExpired;
+                timerDisplay.TimerExpired += HandleTimerExpired;
             }
             else if (!isDesktop && timerDisplayMobile != null)
             {
                 timerDisplayMobile.StartTimer(0f); // Immediate start on mobile
-                timerDisplayMobile.OnTimerExpired += HandleTimerExpired;
+                timerDisplayMobile.TimerExpired += HandleTimerExpired;
             }
 
             // Play question intro VO (desktop only)

--- a/Scripts/UI/TimerDisplay.cs
+++ b/Scripts/UI/TimerDisplay.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
@@ -39,6 +40,8 @@ namespace RobotsGame.UI
         public bool IsRunning => isRunning;
         public bool IsExpired => timeRemaining <= 0f;
 
+        public event Action TimerExpired;
+
         // ===========================
         // LIFECYCLE
         // ===========================
@@ -77,7 +80,7 @@ namespace RobotsGame.UI
                 {
                     timeRemaining = 0;
                     isRunning = false;
-                    OnTimerExpired();
+                    NotifyTimerExpired();
                 }
 
                 UpdateTimerDisplay();
@@ -228,10 +231,11 @@ namespace RobotsGame.UI
         // EVENTS
         // ===========================
 
-        private void OnTimerExpired()
+        private void NotifyTimerExpired()
         {
             Debug.Log("Timer expired!");
             // Controller will handle submission
+            TimerExpired?.Invoke();
         }
 
         // ===========================


### PR DESCRIPTION
## Summary
- add a TimerExpired event to TimerDisplay and fire it when the countdown reaches zero
- update QuestionScreenController subscriptions to use the new TimerExpired event name

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dde894bbb4832ea730aed35e594d72