### PR TITLE
Clear vote tracking when starting rounds

### DIFF
--- a/Scripts/Managers/GameManager.cs
+++ b/Scripts/Managers/GameManager.cs
@@ -236,6 +236,7 @@ namespace RobotsGame.Managers
             currentAnswers.Clear();
             currentRoundScores.Clear();
             currentQuestion = null;
+            ClearVoteTracking();
         }
 
         public void StartNextRound(Question question)
@@ -244,6 +245,7 @@ namespace RobotsGame.Managers
             currentQuestion = question;
             currentAnswers.Clear();
             currentRoundScores.Clear();
+            ClearVoteTracking();
 
             // Initialize round scores for all players
             foreach (var player in players)


### PR DESCRIPTION
## Summary
- reset vote tracking when new rounds begin so elimination/final vote data starts clean
- clear stored votes as part of starting a new game to avoid stale selections carrying over

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dde8414cf8832ea586415fc18e4a2d