### PR TITLE
Enable scene loading in screen transitions

### DIFF
--- a/Scripts/Screens/EliminationScreenController.cs
+++ b/Scripts/Screens/EliminationScreenController.cs
@@ -434,13 +434,7 @@ namespace RobotsGame.Screens
             FadeTransition.Instance.FadeOut(0.5f, () =>
             {
                 Debug.Log($"Transitioning to {nextSceneName}");
-                // SceneManager.LoadScene(nextSceneName);
-
-                // Temporary: fade back in
-                DOVirtual.DelayedCall(0.5f, () =>
-                {
-                    FadeTransition.Instance.FadeIn(1f);
-                });
+                SceneManager.LoadScene(nextSceneName);
             });
         }
 

--- a/Scripts/Screens/FinalResultsController.cs
+++ b/Scripts/Screens/FinalResultsController.cs
@@ -305,13 +305,7 @@ namespace RobotsGame.Screens
             {
                 GameManager.Instance.ResetGame();
                 Debug.Log("Transitioning to LandingPage (new game)");
-                // SceneManager.LoadScene("LandingPage");
-
-                // Temporary: fade back in
-                DOVirtual.DelayedCall(0.5f, () =>
-                {
-                    FadeTransition.Instance.FadeIn(1f);
-                });
+                SceneManager.LoadScene("LandingPage");
             });
         }
 

--- a/Scripts/Screens/LandingPageController.cs
+++ b/Scripts/Screens/LandingPageController.cs
@@ -208,25 +208,17 @@ namespace RobotsGame.Screens
 
         private void GoToNextScene()
         {
-            // This would be the join room / lobby scene
-            // For now, just log the transition
-            Debug.Log($"Transitioning to {nextSceneName}");
-
-            // Uncomment when scene exists:
-            // SceneManager.LoadScene(nextSceneName);
-
-            // Temporary: fade back in to show we completed the cycle
-            if (isDesktop)
+            if (!isTransitioning)
             {
-                DOVirtual.DelayedCall(0.5f, () =>
-                {
-                    FadeTransition.Instance.FadeIn(1f, () =>
-                    {
-                        isTransitioning = false;
-                        Debug.Log("Landing page cycle complete. Add next scene to continue.");
-                    });
-                });
+                Debug.LogWarning("GoToNextScene called without an active transition. Ignoring.");
+                return;
             }
+
+            // Prevent any further attempts while we load the next scene.
+            isTransitioning = false;
+
+            Debug.Log($"Transitioning to {nextSceneName}");
+            SceneManager.LoadScene(nextSceneName);
         }
 
         // ===========================

--- a/Scripts/Screens/ResultsScreenController.cs
+++ b/Scripts/Screens/ResultsScreenController.cs
@@ -531,13 +531,7 @@ namespace RobotsGame.Screens
             FadeTransition.Instance.FadeOut(0.5f, () =>
             {
                 Debug.Log($"Transitioning to {targetScene}");
-                // SceneManager.LoadScene(targetScene);
-
-                // Temporary: fade back in
-                DOVirtual.DelayedCall(0.5f, () =>
-                {
-                    FadeTransition.Instance.FadeIn(1f);
-                });
+                SceneManager.LoadScene(targetScene);
             });
         }
 

--- a/Scripts/Screens/VotingScreenController.cs
+++ b/Scripts/Screens/VotingScreenController.cs
@@ -378,13 +378,7 @@ namespace RobotsGame.Screens
             FadeTransition.Instance.FadeOut(0.5f, () =>
             {
                 Debug.Log($"Transitioning to {nextSceneName}");
-                // SceneManager.LoadScene(nextSceneName);
-
-                // Temporary: fade back in
-                DOVirtual.DelayedCall(0.5f, () =>
-                {
-                    FadeTransition.Instance.FadeIn(1f);
-                });
+                SceneManager.LoadScene(nextSceneName);
             });
         }
 


### PR DESCRIPTION
## Summary
- replace the landing page transition placeholder with an actual scene load guarded by the transition flag
- restore scene loading in elimination, voting, results, and final results controllers while keeping existing fade animations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dde81d3738832e849f1251272b99e8