### PR TITLE
Add missing AudioManager namespace to VotingAnswerList

### DIFF
--- a/Scripts/UI/VotingAnswerList.cs
+++ b/Scripts/UI/VotingAnswerList.cs
@@ -5,6 +5,7 @@ using DG.Tweening;
 using System.Collections.Generic;
 using RobotsGame.Core;
 using RobotsGame.Data;
+using RobotsGame.Managers;
 
 namespace RobotsGame.UI
 {


### PR DESCRIPTION
## Summary
- import the RobotsGame.Managers namespace in VotingAnswerList so AudioManager resolves

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dde9806d60832e8add7a4fe5cefa94