### PR TITLE
Raise timer expiration event and hook question screen

### DIFF
--- a/Scripts/Screens/QuestionScreenController.cs
+++ b/Scripts/Screens/QuestionScreenController.cs
@@ -110,12 +110,7 @@ namespace RobotsGame.Screens
                 mobileInput.OnAnswerSubmitted -= SubmitAnswer;
             }
 
-            // Unsubscribe from timer events
-            if (timerDisplay != null)
-                timerDisplay.TimerExpired -= HandleTimerExpired;
-
-            if (timerDisplayMobile != null)
-                timerDisplayMobile.TimerExpired -= HandleTimerExpired;
+            UnsubscribeFromTimerEvents();
 
             // Kill DOTween animations
             DOTween.Kill(this);
@@ -276,15 +271,15 @@ namespace RobotsGame.Screens
                 return;
 
             // Start timer
+            SubscribeToTimerEvents();
+
             if (isDesktop && timerDisplay != null)
             {
                 timerDisplay.StartTimer();
-                timerDisplay.TimerExpired += HandleTimerExpired;
             }
             else if (!isDesktop && timerDisplayMobile != null)
             {
                 timerDisplayMobile.StartTimer(0f); // Immediate start on mobile
-                timerDisplayMobile.TimerExpired += HandleTimerExpired;
             }
 
             // Play question intro VO (desktop only)
@@ -299,6 +294,33 @@ namespace RobotsGame.Screens
 
             // Fade in from black
             FadeTransition.Instance.FadeIn(1f);
+        }
+
+        private void SubscribeToTimerEvents()
+        {
+            UnsubscribeFromTimerEvents();
+
+            if (isDesktop && timerDisplay != null)
+            {
+                timerDisplay.TimerExpired += HandleTimerExpired;
+            }
+            else if (!isDesktop && timerDisplayMobile != null)
+            {
+                timerDisplayMobile.TimerExpired += HandleTimerExpired;
+            }
+        }
+
+        private void UnsubscribeFromTimerEvents()
+        {
+            if (timerDisplay != null)
+            {
+                timerDisplay.TimerExpired -= HandleTimerExpired;
+            }
+
+            if (timerDisplayMobile != null)
+            {
+                timerDisplayMobile.TimerExpired -= HandleTimerExpired;
+            }
         }
 
         private void DisableAnswerUI()

--- a/Scripts/UI/TimerDisplay.cs
+++ b/Scripts/UI/TimerDisplay.cs
@@ -80,7 +80,7 @@ namespace RobotsGame.UI
                 {
                     timeRemaining = 0;
                     isRunning = false;
-                    NotifyTimerExpired();
+                    OnTimerExpired();
                 }
 
                 UpdateTimerDisplay();
@@ -231,11 +231,11 @@ namespace RobotsGame.UI
         // EVENTS
         // ===========================
 
-        private void NotifyTimerExpired()
+        private void OnTimerExpired()
         {
+            TimerExpired?.Invoke();
             Debug.Log("Timer expired!");
             // Controller will handle submission
-            TimerExpired?.Invoke();
         }
 
         // ===========================


### PR DESCRIPTION
## Summary
- invoke the timer expiration event before logging in `TimerDisplay`
- rename the internal handler to `OnTimerExpired`
- centralize timer event subscription in `QuestionScreenController`

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68dde97aeae8832e9db75b95e8452047