### PR TITLE
Re-enable voting screen scene transition

### DIFF
--- a/Scripts/Screens/VotingScreenController.cs
+++ b/Scripts/Screens/VotingScreenController.cs
@@ -378,13 +378,7 @@ namespace RobotsGame.Screens
             FadeTransition.Instance.FadeOut(0.5f, () =>
             {
                 Debug.Log($"Transitioning to {nextSceneName}");
-                // SceneManager.LoadScene(nextSceneName);
-
-                // Temporary: fade back in
-                DOVirtual.DelayedCall(0.5f, () =>
-                {
-                    FadeTransition.Instance.FadeIn(1f);
-                });
+                SceneManager.LoadScene(nextSceneName);
             });
         }
 


### PR DESCRIPTION
## Summary
- restore the voting screen's fade-out transition so it loads the next scene again

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dde979598c832e99708ca3c2b4ace8