### PR TITLE
Adjust responsive initialization for screen controllers

### DIFF
--- a/Scripts/Screens/EliminationScreenController.cs
+++ b/Scripts/Screens/EliminationScreenController.cs
@@ -65,14 +65,12 @@ namespace RobotsGame.Screens
             responsiveUI = GetComponentInParent<ResponsiveUI>();
             if (responsiveUI == null)
                 responsiveUI = FindObjectOfType<ResponsiveUI>();
-
-            isDesktop = responsiveUI != null ? responsiveUI.IsDesktop : (Screen.width > GameConstants.UI.MobileMaxWidth);
-
-            SetupPlatformContent();
         }
 
         private void Start()
         {
+            InitializePlatform();
+
             // Get answers from GameManager
             allAnswers = GameManager.Instance.CurrentAnswers;
 
@@ -136,6 +134,20 @@ namespace RobotsGame.Screens
 
             if (mobileContent != null)
                 mobileContent.SetActive(!isDesktop);
+        }
+
+        private void InitializePlatform()
+        {
+            if (responsiveUI != null)
+            {
+                isDesktop = responsiveUI.IsDesktop;
+            }
+            else
+            {
+                isDesktop = Screen.width > GameConstants.UI.MobileMaxWidth;
+            }
+
+            SetupPlatformContent();
         }
 
         private void SetupDesktop(string playerAnswer)

--- a/Scripts/Screens/FinalResultsController.cs
+++ b/Scripts/Screens/FinalResultsController.cs
@@ -62,14 +62,12 @@ namespace RobotsGame.Screens
             responsiveUI = GetComponentInParent<ResponsiveUI>();
             if (responsiveUI == null)
                 responsiveUI = FindObjectOfType<ResponsiveUI>();
-
-            isDesktop = responsiveUI != null ? responsiveUI.IsDesktop : (Screen.width > GameConstants.UI.MobileMaxWidth);
-
-            SetupPlatformContent();
         }
 
         private void Start()
         {
+            InitializePlatform();
+
             // Get ranked players
             rankedPlayers = GameManager.Instance.GetRankedPlayers();
 
@@ -105,6 +103,20 @@ namespace RobotsGame.Screens
 
             if (mobileContent != null)
                 mobileContent.SetActive(!isDesktop);
+        }
+
+        private void InitializePlatform()
+        {
+            if (responsiveUI != null)
+            {
+                isDesktop = responsiveUI.IsDesktop;
+            }
+            else
+            {
+                isDesktop = Screen.width > GameConstants.UI.MobileMaxWidth;
+            }
+
+            SetupPlatformContent();
         }
 
         private void SetupDesktop()

--- a/Scripts/Screens/LandingPageController.cs
+++ b/Scripts/Screens/LandingPageController.cs
@@ -47,14 +47,12 @@ namespace RobotsGame.Screens
             {
                 responsiveUI = FindObjectOfType<ResponsiveUI>();
             }
-
-            isDesktop = responsiveUI != null ? responsiveUI.IsDesktop : (Screen.width > GameConstants.UI.MobileMaxWidth);
-
-            SetupPlatformContent();
         }
 
         private void Start()
         {
+            InitializePlatform();
+
             if (isDesktop)
             {
                 SetupDesktop();
@@ -88,6 +86,20 @@ namespace RobotsGame.Screens
 
             if (mobileContent != null)
                 mobileContent.SetActive(!isDesktop);
+        }
+
+        private void InitializePlatform()
+        {
+            if (responsiveUI != null)
+            {
+                isDesktop = responsiveUI.IsDesktop;
+            }
+            else
+            {
+                isDesktop = Screen.width > GameConstants.UI.MobileMaxWidth;
+            }
+
+            SetupPlatformContent();
         }
 
         private void SetupDesktop()

--- a/Scripts/Screens/QuestionScreenController.cs
+++ b/Scripts/Screens/QuestionScreenController.cs
@@ -64,14 +64,12 @@ namespace RobotsGame.Screens
             responsiveUI = GetComponentInParent<ResponsiveUI>();
             if (responsiveUI == null)
                 responsiveUI = FindObjectOfType<ResponsiveUI>();
-
-            isDesktop = responsiveUI != null ? responsiveUI.IsDesktop : (Screen.width > GameConstants.UI.MobileMaxWidth);
-
-            SetupPlatformContent();
         }
 
         private void Start()
         {
+            InitializePlatform();
+
             DisableAnswerUI();
 
             // Setup answer validation callbacks
@@ -228,6 +226,20 @@ namespace RobotsGame.Screens
 
             if (mobileContent != null)
                 mobileContent.SetActive(!isDesktop);
+        }
+
+        private void InitializePlatform()
+        {
+            if (responsiveUI != null)
+            {
+                isDesktop = responsiveUI.IsDesktop;
+            }
+            else
+            {
+                isDesktop = Screen.width > GameConstants.UI.MobileMaxWidth;
+            }
+
+            SetupPlatformContent();
         }
 
         private void SetupQuestion(Question question)

--- a/Scripts/Screens/ResultsScreenController.cs
+++ b/Scripts/Screens/ResultsScreenController.cs
@@ -65,14 +65,12 @@ namespace RobotsGame.Screens
             responsiveUI = GetComponentInParent<ResponsiveUI>();
             if (responsiveUI == null)
                 responsiveUI = FindObjectOfType<ResponsiveUI>();
-
-            isDesktop = responsiveUI != null ? responsiveUI.IsDesktop : (Screen.width > GameConstants.UI.MobileMaxWidth);
-
-            SetupPlatformContent();
         }
 
         private void Start()
         {
+            InitializePlatform();
+
             var gameManager = GameManager.Instance;
             bool isMultiplayerGame = gameManager != null && gameManager.IsMultiplayer;
 
@@ -180,6 +178,20 @@ namespace RobotsGame.Screens
 
             if (mobileContent != null)
                 mobileContent.SetActive(!isDesktop);
+        }
+
+        private void InitializePlatform()
+        {
+            if (responsiveUI != null)
+            {
+                isDesktop = responsiveUI.IsDesktop;
+            }
+            else
+            {
+                isDesktop = Screen.width > GameConstants.UI.MobileMaxWidth;
+            }
+
+            SetupPlatformContent();
         }
 
         private void SetupDesktop()

--- a/Scripts/Screens/VotingScreenController.cs
+++ b/Scripts/Screens/VotingScreenController.cs
@@ -64,14 +64,12 @@ namespace RobotsGame.Screens
             responsiveUI = GetComponentInParent<ResponsiveUI>();
             if (responsiveUI == null)
                 responsiveUI = FindObjectOfType<ResponsiveUI>();
-
-            isDesktop = responsiveUI != null ? responsiveUI.IsDesktop : (Screen.width > GameConstants.UI.MobileMaxWidth);
-
-            SetupPlatformContent();
         }
 
         private void Start()
         {
+            InitializePlatform();
+
             // Get question and answers from GameManager
             currentQuestion = GameManager.Instance.CurrentQuestion;
 
@@ -155,6 +153,20 @@ namespace RobotsGame.Screens
 
             if (mobileContent != null)
                 mobileContent.SetActive(!isDesktop);
+        }
+
+        private void InitializePlatform()
+        {
+            if (responsiveUI != null)
+            {
+                isDesktop = responsiveUI.IsDesktop;
+            }
+            else
+            {
+                isDesktop = Screen.width > GameConstants.UI.MobileMaxWidth;
+            }
+
+            SetupPlatformContent();
         }
 
         private void SetupDesktop(string playerAnswer)


### PR DESCRIPTION
## Summary
- delay platform detection in the six screen controllers until Start so ResponsiveUI has finished updating
- add a shared InitializePlatform helper in each controller that falls back to Screen.width only when ResponsiveUI is missing
- ensure layout-specific setup logic runs after the new initialization to display the correct UI on mobile

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dde9bf7754832e9302f66e672b85fd