### PR TITLE
Add safety checks to MobileAnswerInput initialization

### DIFF
--- a/Scripts/UI/MobileAnswerInput.cs
+++ b/Scripts/UI/MobileAnswerInput.cs
@@ -12,6 +12,7 @@ namespace RobotsGame.UI
     /// Manages the mobile answer input field with validation and flash warnings.
     /// Based on unityspec.md QuestionScreen - Mobile InputField specifications.
     /// </summary>
+    [RequireComponent(typeof(TMP_InputField))]
     public class MobileAnswerInput : MonoBehaviour
     {
         [Header("UI References")]
@@ -51,8 +52,12 @@ namespace RobotsGame.UI
         // ===========================
         private void Awake()
         {
-            if (inputField == null)
-                inputField = GetComponent<TMP_InputField>();
+            if (!TryGetComponent(out inputField))
+            {
+                Debug.LogError($"{nameof(MobileAnswerInput)} on '{gameObject.name}' requires a {nameof(TMP_InputField)} component.", this);
+                enabled = false;
+                return;
+            }
 
             if (inputBackground == null)
                 inputBackground = GetComponent<Image>();
@@ -210,7 +215,7 @@ namespace RobotsGame.UI
             inputField.text = warningMessage;
             if (inputBackground != null)
                 inputBackground.DOColor(warningBackgroundColor, 0.2f);
-            inputField.textComponent.DOColor(warningTextColor, 0.2f);
+            inputField.textComponent?.DOColor(warningTextColor, 0.2f);
 
             // Wait for flash duration
             yield return new WaitForSeconds(flashDuration);
@@ -229,7 +234,7 @@ namespace RobotsGame.UI
 
             if (inputBackground != null)
                 inputBackground.DOColor(normalBackgroundColor, 0.2f);
-            inputField.textComponent.DOColor(normalTextColor, 0.2f);
+            inputField.textComponent?.DOColor(normalTextColor, 0.2f);
 
             // Re-enable input
             inputField.interactable = !hasSubmitted;


### PR DESCRIPTION
## Summary
- ensure MobileAnswerInput always has a TMP_InputField via RequireComponent and runtime validation
- guard Awake against missing input fields and bail out with a descriptive error
- make flash warning color tweens resilient when the text component is absent

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dde9cb2750832ea18b95b138a85744