### PR TITLE
Reset vote tracking at round start

### DIFF
--- a/Scripts/Managers/GameManager.cs
+++ b/Scripts/Managers/GameManager.cs
@@ -241,11 +241,16 @@ namespace RobotsGame.Managers
 
         public void StartNextRound(Question question)
         {
+            // Ensure no stale vote data leaks into the new round
+            ClearVoteTracking();
+
             currentRound++;
             currentQuestion = question;
+            currentQuestion?.ClearEliminatedAnswers();
             currentAnswers.Clear();
             currentRoundScores.Clear();
-            ClearVoteTracking();
+            eliminationResults = new VoteResults();
+            votingResults = new VoteResults();
 
             // Initialize round scores for all players
             foreach (var player in players)

--- a/Scripts/Tests/GameManagerVoteResetTests.cs
+++ b/Scripts/Tests/GameManagerVoteResetTests.cs
@@ -1,0 +1,68 @@
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using RobotsGame.Core;
+using RobotsGame.Data;
+using RobotsGame.Managers;
+
+namespace RobotsGame.Tests
+{
+    public class GameManagerVoteResetTests
+    {
+        private GameObject testObject;
+        private GameManager gameManager;
+
+        [SetUp]
+        public void SetUp()
+        {
+            testObject = new GameObject("GameManagerTestObject");
+            gameManager = testObject.AddComponent<GameManager>();
+
+            // Seed with a single player so score containers are created
+            gameManager.Players.Add(new Player("Player One", "icon1"));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(testObject);
+            var instanceField = typeof(GameManager).GetField("_instance", BindingFlags.NonPublic | BindingFlags.Static);
+            instanceField?.SetValue(null, null);
+        }
+
+        [Test]
+        public void StartNextRound_ClearsVotesAndEliminationState()
+        {
+            var initialQuestion = new Question(
+                "q0",
+                "Who is the robot?",
+                "Correct",
+                "Robot",
+                GameConstants.QuestionType.Text,
+                0
+            );
+
+            // Begin the first round so vote dictionaries are initialized
+            gameManager.StartNextRound(initialQuestion);
+
+            gameManager.RecordEliminationVote("Player One", "Answer A");
+            gameManager.RecordFinalVote("Player One", "Answer B");
+
+            var nextQuestion = new Question(
+                "q1",
+                "Who is the imposter?",
+                "Correct",
+                "Robot",
+                GameConstants.QuestionType.Text,
+                1
+            );
+            nextQuestion.AddEliminatedAnswer("Stale Answer");
+
+            gameManager.StartNextRound(nextQuestion);
+
+            Assert.IsNull(gameManager.GetPlayerEliminationVote("Player One"), "Elimination vote should be cleared between rounds.");
+            Assert.IsNull(gameManager.GetPlayerFinalVote("Player One"), "Final vote should be cleared between rounds.");
+            Assert.IsEmpty(nextQuestion.EliminatedAnswers, "Eliminated answers should be cleared for the new round question.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- clear vote tracking at the top of StartNextRound so per-round dictionaries start empty
- reset the incoming question's elimination list and fresh vote result containers for each round
- add an edit-mode test to fail fast if votes persist between rounds

## Testing
- not run (requires Unity test runner)


------
https://chatgpt.com/codex/tasks/task_e_68dde9ea30f8832eaaeda6e26db51ecc