### PR TITLE
Use authoritative vote results on results screen

### DIFF
--- a/Scripts/Data/RoundScore.cs
+++ b/Scripts/Data/RoundScore.cs
@@ -65,6 +65,24 @@ namespace RobotsGame.Data
             RecalculateTotal();
         }
 
+        public void ApplyServerBreakdown(int correctPoints, int robotPoints, int votesCount, int votesPoints, int fooledPoints, int? totalOverride = null)
+        {
+            correctAnswerPoints = correctPoints;
+            robotIdentifiedPoints = robotPoints;
+            votesReceivedCount = votesCount;
+            votesReceivedPoints = votesPoints;
+            this.fooledPoints = fooledPoints;
+
+            if (totalOverride.HasValue)
+            {
+                total = totalOverride.Value;
+            }
+            else
+            {
+                RecalculateTotal();
+            }
+        }
+
         private void RecalculateTotal()
         {
             total = correctAnswerPoints + robotIdentifiedPoints + votesReceivedPoints + fooledPoints;

--- a/Scripts/Data/VoteResults.cs
+++ b/Scripts/Data/VoteResults.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using UnityEngine;
 
 namespace RobotsGame.Data
@@ -18,12 +19,31 @@ namespace RobotsGame.Data
         // Dictionary stored as two parallel lists for serialization
         [SerializeField] private List<string> voteAnswers = new List<string>();
         [SerializeField] private List<int> voteCounts = new List<int>();
+        [SerializeField] private List<string> voterNames = new List<string>();
+        [SerializeField] private List<string> voterAnswers = new List<string>();
 
         private Dictionary<string, int> voteCountsDict;
+        private Dictionary<string, string> playerVotesDict;
 
         public string EliminatedAnswer => eliminatedAnswer;
         public bool TieOccurred => tieOccurred;
         public int TotalVotesCast => totalVotesCast;
+        public IReadOnlyDictionary<string, int> VoteCounts
+        {
+            get
+            {
+                EnsureVoteCountsDictionary();
+                return new ReadOnlyDictionary<string, int>(voteCountsDict);
+            }
+        }
+        public IReadOnlyDictionary<string, string> PlayerVotes
+        {
+            get
+            {
+                EnsurePlayerVotesDictionary();
+                return new ReadOnlyDictionary<string, string>(playerVotesDict);
+            }
+        }
 
         public VoteResults()
         {
@@ -31,42 +51,151 @@ namespace RobotsGame.Data
             tieOccurred = false;
             totalVotesCast = 0;
             voteCountsDict = new Dictionary<string, int>();
+            playerVotesDict = new Dictionary<string, string>();
         }
 
         public void AddVote(string answerText)
         {
-            if (voteCountsDict == null)
-                voteCountsDict = new Dictionary<string, int>();
+            EnsureVoteCountsDictionary();
 
             if (!voteCountsDict.ContainsKey(answerText))
                 voteCountsDict[answerText] = 0;
 
             voteCountsDict[answerText]++;
-            totalVotesCast++;
+            RecalculateTotalVotes();
+            SerializeState();
         }
 
         public int GetVoteCount(string answerText)
         {
-            if (voteCountsDict == null)
-                BuildDictionaryFromLists();
+            EnsureVoteCountsDictionary();
 
             return voteCountsDict.ContainsKey(answerText) ? voteCountsDict[answerText] : 0;
         }
 
         public Dictionary<string, int> GetVoteCounts()
         {
-            if (voteCountsDict == null || voteCountsDict.Count == 0)
-                BuildDictionaryFromLists();
+            EnsureVoteCountsDictionary();
 
             return new Dictionary<string, int>(voteCountsDict);
         }
 
+        public IReadOnlyDictionary<string, string> GetPlayerVotes()
+        {
+            EnsurePlayerVotesDictionary();
+            return new ReadOnlyDictionary<string, string>(playerVotesDict);
+        }
+
+        public void RecordPlayerVote(string playerName, string answerText)
+        {
+            if (string.IsNullOrEmpty(playerName) || string.IsNullOrEmpty(answerText))
+            {
+                return;
+            }
+
+            EnsureVoteCountsDictionary();
+            EnsurePlayerVotesDictionary();
+
+            if (playerVotesDict.TryGetValue(playerName, out var previousAnswer))
+            {
+                if (voteCountsDict.ContainsKey(previousAnswer))
+                {
+                    voteCountsDict[previousAnswer]--;
+                    if (voteCountsDict[previousAnswer] <= 0)
+                    {
+                        voteCountsDict.Remove(previousAnswer);
+                    }
+                }
+            }
+
+            playerVotesDict[playerName] = answerText;
+
+            if (!voteCountsDict.ContainsKey(answerText))
+            {
+                voteCountsDict[answerText] = 0;
+            }
+
+            voteCountsDict[answerText]++;
+            RecalculateTotalVotes();
+            SerializeState();
+        }
+
+        public void ApplyVoteCounts(Dictionary<string, int> counts)
+        {
+            EnsureVoteCountsDictionary();
+            voteCountsDict.Clear();
+
+            if (counts != null)
+            {
+                foreach (var kvp in counts)
+                {
+                    if (string.IsNullOrEmpty(kvp.Key))
+                        continue;
+
+                    voteCountsDict[kvp.Key] = kvp.Value;
+                }
+            }
+
+            RecalculateTotalVotes();
+            SerializeState();
+        }
+
+        public void ApplyPlayerVotes(Dictionary<string, string> votes)
+        {
+            EnsureVoteCountsDictionary();
+            EnsurePlayerVotesDictionary();
+
+            voteCountsDict.Clear();
+            playerVotesDict.Clear();
+
+            if (votes != null)
+            {
+                foreach (var kvp in votes)
+                {
+                    if (string.IsNullOrEmpty(kvp.Key) || string.IsNullOrEmpty(kvp.Value))
+                        continue;
+
+                    playerVotesDict[kvp.Key] = kvp.Value;
+
+                    if (!voteCountsDict.ContainsKey(kvp.Value))
+                    {
+                        voteCountsDict[kvp.Value] = 0;
+                    }
+
+                    voteCountsDict[kvp.Value]++;
+                }
+            }
+
+            RecalculateTotalVotes();
+            SerializeState();
+        }
+
+        public void SetOutcome(string eliminatedAnswer, bool tieOccurred)
+        {
+            this.eliminatedAnswer = eliminatedAnswer;
+            this.tieOccurred = tieOccurred;
+        }
+
+        public void SetTotalVotes(int totalVotes)
+        {
+            totalVotesCast = Mathf.Max(0, totalVotes);
+        }
+
+        public void RecalculateTotalsFromCounts()
+        {
+            RecalculateTotalVotes();
+            SerializeState();
+        }
+
         public void CalculateElimination()
         {
+            EnsureVoteCountsDictionary();
+
             if (voteCountsDict == null || voteCountsDict.Count == 0)
             {
                 tieOccurred = true;
                 eliminatedAnswer = null;
+                totalVotesCast = 0;
                 return;
             }
 
@@ -98,14 +227,80 @@ namespace RobotsGame.Data
                 eliminatedAnswer = topAnswers.Count > 0 ? topAnswers[0] : null;
             }
 
-            // Prepare for serialization
-            SerializeDictionary();
+            RecalculateTotalVotes();
+            SerializeState();
         }
 
-        private void SerializeDictionary()
+        private void EnsureVoteCountsDictionary()
+        {
+            if (voteCountsDict != null)
+            {
+                return;
+            }
+
+            voteCountsDict = new Dictionary<string, int>();
+
+            if (voteAnswers != null && voteAnswers.Count > 0)
+            {
+                for (int i = 0; i < voteAnswers.Count && i < voteCounts.Count; i++)
+                {
+                    string answer = voteAnswers[i];
+                    if (string.IsNullOrEmpty(answer))
+                        continue;
+
+                    voteCountsDict[answer] = voteCounts[i];
+                }
+            }
+
+            RecalculateTotalVotes();
+        }
+
+        private void EnsurePlayerVotesDictionary()
+        {
+            if (playerVotesDict != null)
+            {
+                return;
+            }
+
+            playerVotesDict = new Dictionary<string, string>();
+
+            if (voterNames != null && voterNames.Count > 0 && voterNames.Count == voterAnswers.Count)
+            {
+                for (int i = 0; i < voterNames.Count; i++)
+                {
+                    string name = voterNames[i];
+                    string answer = voterAnswers[i];
+
+                    if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(answer))
+                        continue;
+
+                    playerVotesDict[name] = answer;
+                }
+
+                EnsureVoteCountsDictionary();
+                voteCountsDict.Clear();
+
+                foreach (var kvp in playerVotesDict)
+                {
+                    if (!voteCountsDict.ContainsKey(kvp.Value))
+                    {
+                        voteCountsDict[kvp.Value] = 0;
+                    }
+
+                    voteCountsDict[kvp.Value]++;
+                }
+
+                RecalculateTotalVotes();
+                SerializeState();
+            }
+        }
+
+        private void SerializeState()
         {
             voteAnswers.Clear();
             voteCounts.Clear();
+            voterNames.Clear();
+            voterAnswers.Clear();
 
             if (voteCountsDict != null)
             {
@@ -115,16 +310,32 @@ namespace RobotsGame.Data
                     voteCounts.Add(kvp.Value);
                 }
             }
+
+            if (playerVotesDict != null)
+            {
+                foreach (var kvp in playerVotesDict)
+                {
+                    voterNames.Add(kvp.Key);
+                    voterAnswers.Add(kvp.Value);
+                }
+            }
         }
 
-        private void BuildDictionaryFromLists()
+        private void RecalculateTotalVotes()
         {
-            voteCountsDict = new Dictionary<string, int>();
-
-            for (int i = 0; i < voteAnswers.Count && i < voteCounts.Count; i++)
+            if (voteCountsDict == null)
             {
-                voteCountsDict[voteAnswers[i]] = voteCounts[i];
+                totalVotesCast = 0;
+                return;
             }
+
+            int total = 0;
+            foreach (var kvp in voteCountsDict)
+            {
+                total += kvp.Value;
+            }
+
+            totalVotesCast = total;
         }
     }
 }

--- a/Scripts/Screens/ResultsScreenController.cs
+++ b/Scripts/Screens/ResultsScreenController.cs
@@ -126,10 +126,7 @@ namespace RobotsGame.Screens
                 return;
             }
 
-            VoteResults eliminationResults = new VoteResults();
-            VoteResults votingResults = new VoteResults();
-
-            gameManager.CalculateRoundScores(eliminationResults, votingResults);
+            gameManager.CalculateRoundScores();
         }
 
         private IEnumerator WaitForQuestionData()
@@ -371,13 +368,72 @@ namespace RobotsGame.Screens
 
             robotDecoyPanel.gameObject.SetActive(true);
 
-            // Get players who were not fooled vs fooled
-            List<Player> notFooled = new List<Player>();
-            List<Player> fooled = new List<Player>();
+            var eliminationResults = gameManager.EliminationResults;
+            var votingResults = gameManager.VotingResults;
 
-            // Simplified: In real game, would check elimination votes
-            // For now, assume all players not fooled
-            notFooled.AddRange(allPlayers);
+            HashSet<string> notFooledNames = new HashSet<string>();
+            if (eliminationResults != null)
+            {
+                foreach (var kvp in eliminationResults.GetPlayerVotes())
+                {
+                    if (kvp.Value == currentQuestion.RobotAnswer)
+                    {
+                        notFooledNames.Add(kvp.Key);
+                    }
+                }
+            }
+
+            HashSet<string> fooledNames = new HashSet<string>();
+            if (votingResults != null)
+            {
+                foreach (var kvp in votingResults.GetPlayerVotes())
+                {
+                    if (kvp.Value == currentQuestion.RobotAnswer)
+                    {
+                        fooledNames.Add(kvp.Key);
+                    }
+                }
+            }
+
+            foreach (var name in fooledNames)
+            {
+                notFooledNames.Remove(name);
+            }
+
+            List<Player> notFooled = new List<Player>();
+            foreach (var name in notFooledNames)
+            {
+                var player = gameManager.GetPlayer(name);
+                if (player != null)
+                {
+                    notFooled.Add(player);
+                }
+            }
+
+            List<Player> fooled = new List<Player>();
+            foreach (var name in fooledNames)
+            {
+                var player = gameManager.GetPlayer(name);
+                if (player != null)
+                {
+                    fooled.Add(player);
+                }
+            }
+
+            if (notFooled.Count == 0 && fooled.Count == 0)
+            {
+                notFooled.AddRange(allPlayers);
+            }
+            else
+            {
+                foreach (var player in allPlayers)
+                {
+                    if (!notFooledNames.Contains(player.PlayerName) && !fooledNames.Contains(player.PlayerName))
+                    {
+                        notFooled.Add(player);
+                    }
+                }
+            }
 
             var scoring = GameConstants.Scoring.GetScoring(gameManager.GameMode);
 
@@ -414,13 +470,21 @@ namespace RobotsGame.Screens
 
             playerAnswersPanel.gameObject.SetActive(true);
 
-            // Get vote counts (simplified - would come from voting phase)
             Dictionary<string, int> voteCounts = new Dictionary<string, int>();
+            var votingResults = gameManager.VotingResults;
+            if (votingResults != null)
+            {
+                foreach (var kvp in votingResults.GetVoteCounts())
+                {
+                    voteCounts[kvp.Key] = kvp.Value;
+                }
+            }
+
             foreach (var answer in allAnswers)
             {
-                if (answer.Type == GameConstants.AnswerType.Player)
+                if (answer.Type == GameConstants.AnswerType.Player && !voteCounts.ContainsKey(answer.Text))
                 {
-                    voteCounts[answer.Text] = Random.Range(0, 3); // Mock votes
+                    voteCounts[answer.Text] = 0;
                 }
             }
 


### PR DESCRIPTION
## Summary
- expose the GameManager round score and vote state so other screens can consume host-calculated data
- expand VoteResults/RoundScore handling to track player ballots and apply server-provided tallies
- drive the results screen panels from authoritative elimination and voting results instead of placeholder values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dde8221184832ead6884af094d569f