### PR TITLE
Fix AudioManager singleton initialization and guard callers

### DIFF
--- a/Scripts/Managers/AudioManagerConfiguration.cs
+++ b/Scripts/Managers/AudioManagerConfiguration.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace RobotsGame.Managers
+{
+    /// <summary>
+    /// Scriptable object configuration that provides a pre-configured AudioManager prefab.
+    /// </summary>
+    [CreateAssetMenu(fileName = "AudioManagerConfiguration", menuName = "RobotsGame/Audio/AudioManager Configuration")]
+    public class AudioManagerConfiguration : ScriptableObject
+    {
+        [SerializeField] private GameObject audioManagerPrefab;
+
+        public GameObject AudioManagerPrefab => audioManagerPrefab;
+    }
+}

--- a/Scripts/Screens/EliminationScreenController.cs
+++ b/Scripts/Screens/EliminationScreenController.cs
@@ -403,7 +403,10 @@ namespace RobotsGame.Screens
                 else
                 {
                     // Mobile: simpler result display or skip to transition
-                    AudioManager.Instance.PlayVoiceOver(GameConstants.Audio.VO_RobotAnswerGone);
+                    if (AudioManager.TryGetInstance(out var audioManager))
+                    {
+                        audioManager.PlayVoiceOver(GameConstants.Audio.VO_RobotAnswerGone);
+                    }
 
                     DOVirtual.DelayedCall(3f, () =>
                     {
@@ -426,7 +429,10 @@ namespace RobotsGame.Screens
             else
             {
                 // Mobile: simpler tie display
-                AudioManager.Instance.PlayVoiceOver(GameConstants.Audio.VO_NoRobotAnswerGone);
+                if (AudioManager.TryGetInstance(out var audioManager))
+                {
+                    audioManager.PlayVoiceOver(GameConstants.Audio.VO_NoRobotAnswerGone);
+                }
 
                 if (headerText != null)
                 {

--- a/Scripts/Screens/LandingPageController.cs
+++ b/Scripts/Screens/LandingPageController.cs
@@ -104,8 +104,10 @@ namespace RobotsGame.Screens
                 // Start playing
                 videoPlayer.Play();
 
-                // Play voice over for rules
-                AudioManager.Instance.PlayVoiceOver(GameConstants.Audio.VO_LandingRules);
+                if (AudioManager.TryGetInstance(out var audioManager))
+                {
+                    audioManager.PlayVoiceOver(GameConstants.Audio.VO_LandingRules);
+                }
             }
 
             // Setup start button
@@ -171,8 +173,10 @@ namespace RobotsGame.Screens
 
             isTransitioning = true;
 
-            // Stop any voice overs
-            AudioManager.Instance.StopVoiceOver();
+            if (AudioManager.TryGetInstance(out var audioManager))
+            {
+                audioManager.StopVoiceOver();
+            }
 
             // Button press sound is handled by ButtonEffects component
 
@@ -190,7 +194,10 @@ namespace RobotsGame.Screens
             isTransitioning = true;
 
             // Mobile: immediate transition, no fade
-            AudioManager.Instance.PlayButtonPress();
+            if (AudioManager.TryGetInstance(out var audioManager))
+            {
+                audioManager.PlayButtonPress();
+            }
             GoToNextScene();
         }
 

--- a/Scripts/Screens/QuestionScreenController.cs
+++ b/Scripts/Screens/QuestionScreenController.cs
@@ -155,7 +155,10 @@ namespace RobotsGame.Screens
             {
                 var data = JsonUtility.FromJson<PlayerAnsweredData>(jsonData);
                 playerIconGrid.ShowPlayerIcon(data.playerName);
-                AudioManager.Instance.PlaySFX(GameConstants.Audio.SFX_PlayerIconPop);
+                if (AudioManager.TryGetInstance(out var audioManager))
+                {
+                    audioManager.PlaySFX(GameConstants.Audio.SFX_PlayerIconPop);
+                }
             }
         }
 
@@ -204,7 +207,10 @@ namespace RobotsGame.Screens
             {
                 if (activeTimer != null && activeTimer.TimeRemaining <= 30f)
                 {
-                    AudioManager.Instance.PlayVoiceOver(GameConstants.Audio.VO_QuestionNudge);
+                    if (AudioManager.TryGetInstance(out var audioManager))
+                    {
+                        audioManager.PlayVoiceOver(GameConstants.Audio.VO_QuestionNudge);
+                    }
                     hasPlayedNudgeVO = true;
                 }
             }
@@ -292,7 +298,10 @@ namespace RobotsGame.Screens
             {
                 DOVirtual.DelayedCall(GameConstants.Delays.QuestionIntroDelay, () =>
                 {
-                    AudioManager.Instance.PlayVoiceOver(GameConstants.Audio.VO_QuestionIntro);
+                    if (AudioManager.TryGetInstance(out var audioManager))
+                    {
+                        audioManager.PlayVoiceOver(GameConstants.Audio.VO_QuestionIntro);
+                    }
                     hasPlayedQuestionIntroVO = true;
                 });
             }
@@ -463,7 +472,10 @@ namespace RobotsGame.Screens
                 if (mobileInput != null)
                 {
                     mobileInput.MarkAsSubmitted();
-                    AudioManager.Instance.PlayInputAccept();
+                    if (AudioManager.TryGetInstance(out var audioManager))
+                    {
+                        audioManager.PlayInputAccept();
+                    }
                 }
             }
 

--- a/Scripts/UI/AnswersOverlay.cs
+++ b/Scripts/UI/AnswersOverlay.cs
@@ -75,7 +75,10 @@ namespace RobotsGame.UI
                 isVisible = true;
 
                 // Play swoosh sound
-                AudioManager.Instance.PlayResponsesSwoosh();
+                if (AudioManager.TryGetInstance(out var audioManager))
+                {
+                    audioManager.PlayResponsesSwoosh();
+                }
 
                 // Fade in overlay background
                 canvasGroup.DOFade(1f, 0.3f);

--- a/Scripts/UI/MobileAnswerInput.cs
+++ b/Scripts/UI/MobileAnswerInput.cs
@@ -161,7 +161,10 @@ namespace RobotsGame.UI
                 restoreText: true
             ));
 
-            AudioManager.Instance.PlayFailure();
+            if (AudioManager.TryGetInstance(out var audioManager))
+            {
+                audioManager.PlayFailure();
+            }
         }
 
         /// <summary>
@@ -178,7 +181,10 @@ namespace RobotsGame.UI
                 restoreText: false
             ));
 
-            AudioManager.Instance.PlayFailure();
+            if (AudioManager.TryGetInstance(out var audioManager))
+            {
+                audioManager.PlayFailure();
+            }
         }
 
         /// <summary>
@@ -195,7 +201,10 @@ namespace RobotsGame.UI
                 restoreText: false
             ));
 
-            AudioManager.Instance.PlayFailure();
+            if (AudioManager.TryGetInstance(out var audioManager))
+            {
+                audioManager.PlayFailure();
+            }
         }
 
         private IEnumerator FlashWarningRoutine(string warningMessage, string textToRestore, bool restoreText)

--- a/Scripts/UI/PlayerIconGrid.cs
+++ b/Scripts/UI/PlayerIconGrid.cs
@@ -84,7 +84,10 @@ namespace RobotsGame.UI
             AnimateIconIn(iconObj);
 
             // Play sound
-            AudioManager.Instance.PlayPlayerIconPop();
+            if (AudioManager.TryGetInstance(out var audioManager))
+            {
+                audioManager.PlayPlayerIconPop();
+            }
         }
 
         /// <summary>

--- a/Scripts/UI/RobotCharacter.cs
+++ b/Scripts/UI/RobotCharacter.cs
@@ -88,7 +88,10 @@ namespace RobotsGame.UI
             DOVirtual.DelayedCall(slideInDelay, () =>
             {
                 // Play sound effect
-                AudioManager.Instance.PlayRobotSlideOut();
+                if (AudioManager.TryGetInstance(out var audioManager))
+                {
+                    audioManager.PlayRobotSlideOut();
+                }
 
                 // Slide to original position (0, y)
                 Vector2 targetPos = Vector2.zero;

--- a/Scripts/UI/TimerDisplay.cs
+++ b/Scripts/UI/TimerDisplay.cs
@@ -170,7 +170,11 @@ namespace RobotsGame.UI
 
                 if (!hasPlayedFinalSFX)
                 {
-                    AudioManager.Instance.PlayTimerFinal10Sec();
+                    if (AudioManager.TryGetInstance(out var finalAudioManager))
+                    {
+                        finalAudioManager.PlayTimerFinal10Sec();
+                    }
+
                     hasPlayedFinalSFX = true;
                 }
             }
@@ -182,8 +186,12 @@ namespace RobotsGame.UI
 
                 if (!hasPlayedTimeWarningVO)
                 {
-                    AudioManager.Instance.PlayVoiceOver(GameConstants.Audio.VO_TimeWarning,
-                                                       GameConstants.Delays.TimeWarningDelay);
+                    if (AudioManager.TryGetInstance(out var warningAudioManager))
+                    {
+                        warningAudioManager.PlayVoiceOver(GameConstants.Audio.VO_TimeWarning,
+                                                          GameConstants.Delays.TimeWarningDelay);
+                    }
+
                     hasPlayedTimeWarningVO = true;
                 }
             }

--- a/Scripts/UI/Utilities/ButtonEffects.cs
+++ b/Scripts/UI/Utilities/ButtonEffects.cs
@@ -99,9 +99,9 @@ namespace RobotsGame.UI.Utilities
                 .SetEase(Ease.OutQuad);
 
             // Play sound on press
-            if (playSound)
+            if (playSound && AudioManager.TryGetInstance(out var audioManager))
             {
-                AudioManager.Instance.PlayButtonPress();
+                audioManager.PlayButtonPress();
             }
         }
 
@@ -136,9 +136,9 @@ namespace RobotsGame.UI.Utilities
             pressSequence.Append(transform.DOScale(originalScale * pressScale, transitionDuration * 0.5f).SetEase(Ease.OutQuad));
             pressSequence.Append(transform.DOScale(originalScale * normalScale, transitionDuration * 0.5f).SetEase(Ease.OutQuad));
 
-            if (playSound)
+            if (playSound && AudioManager.TryGetInstance(out var audioManager))
             {
-                AudioManager.Instance.PlayButtonPress();
+                audioManager.PlayButtonPress();
             }
 
             // Trigger button click

--- a/Scripts/UI/VotingAnswerList.cs
+++ b/Scripts/UI/VotingAnswerList.cs
@@ -111,9 +111,9 @@ namespace RobotsGame.UI
             }
 
             // Play success sound if player voted correctly (mobile only)
-            if (isMobile && playerGotItRight)
+            if (isMobile && playerGotItRight && AudioManager.TryGetInstance(out var audioManager))
             {
-                AudioManager.Instance.PlaySuccess();
+                audioManager.PlaySuccess();
             }
 
             // Grey out all other answers


### PR DESCRIPTION
## Summary
- update the AudioManager singleton to locate an existing instance, then fall back to configured prefabs instead of spawning an empty component
- add an AudioManagerConfiguration ScriptableObject hook for specifying the prefab to instantiate when required
- guard all audio play sites so they only fire when a configured AudioManager is available

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68dde9bd1410832e9ad364ca3b3711c2