### PR TITLE
Sync final round results from server

### DIFF
--- a/Scripts/Data/RoundScore.cs
+++ b/Scripts/Data/RoundScore.cs
@@ -72,5 +72,24 @@ namespace RobotsGame.Data
 
         public bool HasPositiveScore() => total > 0;
         public bool HasNegativeScore() => total < 0;
+
+        /// <summary>
+        /// Applies a complete scoring breakdown received from the server.
+        /// </summary>
+        /// <param name="correctPoints">Points awarded for the correct answer.</param>
+        /// <param name="robotPoints">Points awarded for identifying the robot.</param>
+        /// <param name="votesCount">Total votes received in the final voting phase.</param>
+        /// <param name="votesPoints">Points awarded for votes received.</param>
+        /// <param name="fooledTotal">Penalty (usually negative) for being fooled by the robot.</param>
+        /// <param name="totalPoints">Total score change for the round.</param>
+        public void ApplyServerBreakdown(int correctPoints, int robotPoints, int votesCount, int votesPoints, int fooledTotal, int totalPoints)
+        {
+            correctAnswerPoints = correctPoints;
+            robotIdentifiedPoints = robotPoints;
+            votesReceivedCount = Mathf.Max(0, votesCount);
+            votesReceivedPoints = votesPoints;
+            fooledPoints = fooledTotal;
+            total = totalPoints != 0 ? totalPoints : (correctAnswerPoints + robotIdentifiedPoints + votesReceivedPoints + fooledPoints);
+        }
     }
 }

--- a/Scripts/Network/NetworkManager.cs
+++ b/Scripts/Network/NetworkManager.cs
@@ -73,6 +73,8 @@ namespace RobotsGame.Network
         public bool IsConnected => isConnected;
         public string RoomCode => roomCode;
         public List<Player> ConnectedPlayers => new List<Player>(connectedPlayers);
+        public string LocalPlayerName => playerName;
+        public string LocalPlayerIcon => playerIcon;
 
         private void Awake()
         {


### PR DESCRIPTION
## Summary
- deserialize final round score payloads and update GameManager players, score breakdowns, and vote tallies
- surface refreshed vote data to the results and final results screens so they render real multiplayer outcomes
- expose helpers for server-provided breakdowns (RoundScore utility and NetworkManager local player access)

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68dde9e844e0832eb659e8ce68a48b1f