### PR TITLE
Preserve GameManager round state across scenes

### DIFF
--- a/Assets/Scripts/game_manager_script.cs
+++ b/Assets/Scripts/game_manager_script.cs
@@ -14,9 +14,9 @@ public class GameManager : MonoBehaviour
     public GameMode gameMode = GameMode.EightQuestions;
     
     // === GAME STATE ===
-    [System.NonSerialized] public int currentRound = 0;
-    [System.NonSerialized] public bool isHalftimePlayed = false;
-    [System.NonSerialized] public bool isBonusRoundPlayed = false;
+    public int currentRound = 0;
+    public bool isHalftimePlayed = false;
+    public bool isBonusRoundPlayed = false;
     
     // === PLAYER DATA ===
     [Header("Player Data")]


### PR DESCRIPTION
## Summary
- allow GameManager round and special-round flags to persist between scenes by removing the NonSerialized attribute

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e42fdf40b4832e8287c3d4ba05216f