### PR TITLE
Improve mobile lobby connection error handling

### DIFF
--- a/Assets/Scripts/network_manager_script.cs
+++ b/Assets/Scripts/network_manager_script.cs
@@ -83,12 +83,12 @@ public class RWMNetworkManager : NetworkBehaviour
     
     // === CLIENT METHODS ===
     
-    public void JoinGame(string code)
+    public bool JoinGame(string code)
     {
         if (NetworkManager.Singleton == null)
         {
             Debug.LogError("Cannot join game - NetworkManager.Singleton is null");
-            return;
+            return false;
         }
 
         isHost = false;
@@ -96,9 +96,16 @@ public class RWMNetworkManager : NetworkBehaviour
 
         // In a real implementation, this would connect to a relay/matchmaking service
         // For local testing, just start as client
-        NetworkManager.Singleton.StartClient();
+        bool started = NetworkManager.Singleton.StartClient();
+
+        if (!started)
+        {
+            Debug.LogError("Failed to start Unity Netcode client - join aborted");
+            return false;
+        }
 
         Debug.Log("Attempting to join room: " + code);
+        return true;
     }
     
     // === PLAYER MANAGEMENT ===


### PR DESCRIPTION
## Summary
- add network callback handling in the mobile lobby to surface connection failures and disconnections to the player
- guard Unity Netcode client start-up and report join failures back through the existing error UI

## Testing
- Not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e6ff1d3fd8832e839605c37b1e72eb