### PR TITLE
Add mobile haptic feedback across gameplay

### DIFF
--- a/Assets/Scripts/answer_button_controller.cs
+++ b/Assets/Scripts/answer_button_controller.cs
@@ -65,7 +65,11 @@ public class AnswerButtonController : MonoBehaviour, IPointerEnterHandler, IPoin
         if (button != null)
         {
             button.onClick.RemoveAllListeners();
-            button.onClick.AddListener(() => onClickCallback?.Invoke(answerContent));
+            button.onClick.AddListener(() =>
+            {
+                MobileHaptics.SelectionChanged();
+                onClickCallback?.Invoke(answerContent);
+            });
         }
         
         UpdateVisuals();

--- a/Assets/Scripts/bonus_intro_script.cs
+++ b/Assets/Scripts/bonus_intro_script.cs
@@ -56,6 +56,8 @@ public class BonusIntroScreen : MonoBehaviour
     
     public void OnContinueClicked()
     {
+        MobileHaptics.MediumImpact();
+
         // Stop auto-advance
         StopAllCoroutines();
         AdvanceToBonusQuestions();

--- a/Assets/Scripts/bonus_question_script.cs
+++ b/Assets/Scripts/bonus_question_script.cs
@@ -296,6 +296,8 @@ public class BonusQuestionScreen : MonoBehaviour
     
     void OnPlayerSelected(string votedPlayerID, GameObject buttonObj)
     {
+        MobileHaptics.SelectionChanged();
+
         selectedPlayerID = votedPlayerID;
         
         // Visual feedback
@@ -344,9 +346,12 @@ public class BonusQuestionScreen : MonoBehaviour
     
     public void OnSubmitVote()
     {
+        MobileHaptics.MediumImpact();
+
         if (string.IsNullOrEmpty(selectedPlayerID))
         {
             Debug.LogWarning("No player selected!");
+            MobileHaptics.Failure();
             return;
         }
 

--- a/Assets/Scripts/bonus_results_script.cs
+++ b/Assets/Scripts/bonus_results_script.cs
@@ -190,6 +190,8 @@ public class BonusResultsScreen : MonoBehaviour
     
     public void OnContinueClicked()
     {
+        MobileHaptics.MediumImpact();
+
         // Continue to next round (Round 5 for 8Q, Round 7 for 12Q)
         GameManager.Instance.AdvanceToNextScreen();
     }

--- a/Assets/Scripts/button_audio_component.cs
+++ b/Assets/Scripts/button_audio_component.cs
@@ -32,8 +32,10 @@ public class ButtonAudioComponent : MonoBehaviour
     
     void PlayButtonSound()
     {
+        MobileHaptics.LightImpact();
+
         if (AudioManager.Instance == null) return;
-        
+
         switch (buttonType)
         {
             case ButtonType.Standard:

--- a/Assets/Scripts/credits_screen_script.cs
+++ b/Assets/Scripts/credits_screen_script.cs
@@ -99,12 +99,16 @@ public class CreditsScreen : MonoBehaviour
     
     public void OnWebsiteClicked()
     {
+        MobileHaptics.LightImpact();
+
         Debug.Log("Website button clicked");
         Application.OpenURL("https://robotswearingmoustaches.com"); // Replace with actual URL
     }
 
     public void OnNewGameClicked()
     {
+        MobileHaptics.HeavyImpact();
+
         Debug.Log("New Game button clicked");
 
         // Reset game and return to landing

--- a/Assets/Scripts/elimination_screen_script.cs
+++ b/Assets/Scripts/elimination_screen_script.cs
@@ -182,6 +182,8 @@ public class EliminationScreen : MonoBehaviour
     
     void OnAnswerSelected(string answer, GameObject buttonObj)
     {
+        MobileHaptics.SelectionChanged();
+
         selectedAnswer = answer;
         
         // Visual feedback - highlight selected button
@@ -217,9 +219,12 @@ public class EliminationScreen : MonoBehaviour
     
     public void OnSubmitVote()
     {
+        MobileHaptics.MediumImpact();
+
         if (string.IsNullOrEmpty(selectedAnswer))
         {
             Debug.LogWarning("No answer selected!");
+            MobileHaptics.Failure();
             return;
         }
         

--- a/Assets/Scripts/final_results_script.cs
+++ b/Assets/Scripts/final_results_script.cs
@@ -357,6 +357,8 @@ public class FinalResultsScreen : MonoBehaviour
     
     public void OnCreditsClicked()
     {
+        MobileHaptics.MediumImpact();
+
         // Go to Credits scene
         if (SceneTransitionManager.Instance != null)
         {
@@ -370,6 +372,8 @@ public class FinalResultsScreen : MonoBehaviour
 
     public void OnNewGameClicked()
     {
+        MobileHaptics.HeavyImpact();
+
         // Reset game and go back to lobby
         GameManager.Instance.currentRound = 0;
         GameManager.Instance.isHalftimePlayed = false;
@@ -394,6 +398,8 @@ public class FinalResultsScreen : MonoBehaviour
 
     public void OnShareClicked()
     {
+        MobileHaptics.LightImpact();
+
         // Share results functionality
         Debug.Log("Share results clicked");
 
@@ -403,6 +409,8 @@ public class FinalResultsScreen : MonoBehaviour
 
     public void OnWebsiteClicked()
     {
+        MobileHaptics.LightImpact();
+
         // Open game website
         Debug.Log("Website clicked");
         Application.OpenURL("https://robotswearingmoustaches.com"); // Replace with actual URL

--- a/Assets/Scripts/halftime_results_script.cs
+++ b/Assets/Scripts/halftime_results_script.cs
@@ -351,6 +351,8 @@ public class HalftimeResultsScreen : MonoBehaviour
     
     public void OnContinueClicked()
     {
+        MobileHaptics.MediumImpact();
+
         // Continue to Bonus Round
         GameManager.Instance.AdvanceToNextScreen();
     }

--- a/Assets/Scripts/landing_screen_script.cs
+++ b/Assets/Scripts/landing_screen_script.cs
@@ -58,6 +58,8 @@ public class LandingScreen : MonoBehaviour
     
     public void OnStartGameClicked()
     {
+        MobileHaptics.MediumImpact();
+
         // Desktop host starts the game - go to lobby
         Debug.Log("Start Game clicked - transitioning to Lobby");
 
@@ -72,6 +74,8 @@ public class LandingScreen : MonoBehaviour
 
     public void OnJoinGameClicked()
     {
+        MobileHaptics.MediumImpact();
+
         // Mobile player wants to join - go to lobby/join screen
         Debug.Log("Join Game clicked - transitioning to Lobby");
 

--- a/Assets/Scripts/lobby_screen_script.cs
+++ b/Assets/Scripts/lobby_screen_script.cs
@@ -193,6 +193,8 @@ public class LobbyScreen : MonoBehaviour
     
     void OnGameModeSelected(GameManager.GameMode mode)
     {
+        MobileHaptics.SelectionChanged();
+
         GameManager.Instance.gameMode = mode;
         Debug.Log("Game mode selected: " + mode);
         
@@ -223,6 +225,8 @@ public class LobbyScreen : MonoBehaviour
 
     public void OnStartGameClicked()
     {
+        MobileHaptics.MediumImpact();
+
         // Check if we have enough players (minimum 2)
         if (GameManager.Instance.GetAllPlayers().Count < 2)
         {
@@ -240,6 +244,8 @@ public class LobbyScreen : MonoBehaviour
 
     public void OnJoinGameButtonClicked()
     {
+        MobileHaptics.LightImpact();
+
         // User clicked "Join Game" button - show the form
         ShowJoinForm();
     }
@@ -272,6 +278,8 @@ public class LobbyScreen : MonoBehaviour
     
     public void OnPlayerIconSelected(string iconName)
     {
+        MobileHaptics.SelectionChanged();
+
         // Check if icon is available (not already selected by another player)
         if (PlayerManager.Instance != null && !PlayerManager.Instance.IsIconAvailable(iconName))
         {
@@ -293,6 +301,8 @@ public class LobbyScreen : MonoBehaviour
     
     public void OnJoinButtonClicked()
     {
+        MobileHaptics.MediumImpact();
+
         if (nameInput == null || string.IsNullOrEmpty(nameInput.text))
         {
             Debug.LogWarning("Please enter a name!");
@@ -432,6 +442,8 @@ public class LobbyScreen : MonoBehaviour
 
     void ShowErrorMessage(string message)
     {
+        MobileHaptics.Failure();
+
         Debug.LogError("INPUT ERROR: " + message);
 
         // Display error message in UI

--- a/Assets/Scripts/mobile_haptics.cs
+++ b/Assets/Scripts/mobile_haptics.cs
@@ -1,0 +1,167 @@
+using UnityEngine;
+
+/// <summary>
+/// Lightweight helper for triggering platform-specific haptic feedback on mobile devices.
+/// </summary>
+public static class MobileHaptics
+{
+    private const float MinInterval = 0.05f; // Prevent spamming the haptics engine
+    private static float _lastTriggerTime = -10f;
+
+    private enum ImpactStrength
+    {
+        Light,
+        Medium,
+        Heavy
+    }
+
+#if UNITY_ANDROID && !UNITY_EDITOR
+    private static readonly AndroidJavaObject Vibrator;
+    private static readonly int AndroidSdkVersion;
+    private static readonly bool HasAmplitudeControl;
+
+    static MobileHaptics()
+    {
+        try
+        {
+            using (AndroidJavaClass unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
+            {
+                AndroidJavaObject activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
+                if (activity != null)
+                {
+                    Vibrator = activity.Call<AndroidJavaObject>("getSystemService", "vibrator");
+                }
+            }
+
+            using (AndroidJavaClass version = new AndroidJavaClass("android.os.Build$VERSION"))
+            {
+                AndroidSdkVersion = version.GetStatic<int>("SDK_INT");
+            }
+
+            if (Vibrator != null && AndroidSdkVersion >= 26)
+            {
+                HasAmplitudeControl = Vibrator.Call<bool>("hasAmplitudeControl");
+            }
+        }
+        catch (System.Exception ex)
+        {
+            Debug.LogWarning($"MobileHaptics initialization failed: {ex.Message}");
+            Vibrator = null;
+            AndroidSdkVersion = 0;
+            HasAmplitudeControl = false;
+        }
+    }
+#endif
+
+    public static void LightImpact()
+    {
+        Trigger(ImpactStrength.Light);
+    }
+
+    public static void MediumImpact()
+    {
+        Trigger(ImpactStrength.Medium);
+    }
+
+    public static void HeavyImpact()
+    {
+        Trigger(ImpactStrength.Heavy);
+    }
+
+    public static void SelectionChanged()
+    {
+        Trigger(ImpactStrength.Light);
+    }
+
+    public static void Success()
+    {
+        Trigger(ImpactStrength.Medium);
+    }
+
+    public static void Failure()
+    {
+        Trigger(ImpactStrength.Heavy);
+    }
+
+    private static void Trigger(ImpactStrength strength)
+    {
+        if (!Application.isMobilePlatform)
+        {
+            return;
+        }
+
+        if (Time.unscaledTime - _lastTriggerTime < MinInterval)
+        {
+            return;
+        }
+
+        _lastTriggerTime = Time.unscaledTime;
+
+#if UNITY_ANDROID && !UNITY_EDITOR
+        if (Vibrator == null)
+        {
+            Handheld.Vibrate();
+            return;
+        }
+
+        try
+        {
+            long duration = GetDuration(strength);
+
+            if (AndroidSdkVersion >= 26)
+            {
+                using (AndroidJavaClass vibrationEffectClass = new AndroidJavaClass("android.os.VibrationEffect"))
+                {
+                    int amplitude = HasAmplitudeControl ? GetAmplitude(strength) : vibrationEffectClass.GetStatic<int>("DEFAULT_AMPLITUDE");
+                    AndroidJavaObject effect = vibrationEffectClass.CallStatic<AndroidJavaObject>("createOneShot", duration, amplitude);
+                    Vibrator.Call("vibrate", effect);
+                }
+            }
+            else
+            {
+                Vibrator.Call("vibrate", duration);
+            }
+        }
+        catch (System.Exception ex)
+        {
+            Debug.LogWarning($"MobileHaptics vibrate failed: {ex.Message}");
+            Handheld.Vibrate();
+        }
+#elif (UNITY_IOS || UNITY_TVOS) && !UNITY_EDITOR
+        // iOS/tvOS do not expose fine-grained control without plugins, fall back to default vibration
+        Handheld.Vibrate();
+#else
+        Handheld.Vibrate();
+#endif
+    }
+
+#if UNITY_ANDROID && !UNITY_EDITOR
+    private static long GetDuration(ImpactStrength strength)
+    {
+        switch (strength)
+        {
+            case ImpactStrength.Medium:
+                return 40L;
+            case ImpactStrength.Heavy:
+                return 60L;
+            case ImpactStrength.Light:
+            default:
+                return 25L;
+        }
+    }
+
+    private static int GetAmplitude(ImpactStrength strength)
+    {
+        switch (strength)
+        {
+            case ImpactStrength.Medium:
+                return 160;
+            case ImpactStrength.Heavy:
+                return 255;
+            case ImpactStrength.Light:
+            default:
+                return 90;
+        }
+    }
+#endif
+}

--- a/Assets/Scripts/mobile_haptics.cs.meta
+++ b/Assets/Scripts/mobile_haptics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa714e4154ec44d699089c548f777d39
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/picture_question_script.cs
+++ b/Assets/Scripts/picture_question_script.cs
@@ -196,9 +196,12 @@ public class PictureQuestionScreen : MonoBehaviour
     
     void OnSubmitAnswer()
     {
+        MobileHaptics.MediumImpact();
+
         if (answerInput == null || string.IsNullOrEmpty(answerInput.text))
         {
             Debug.LogWarning("Please enter an answer!");
+            MobileHaptics.Failure();
             return;
         }
         

--- a/Assets/Scripts/question_screen_script.cs
+++ b/Assets/Scripts/question_screen_script.cs
@@ -300,6 +300,8 @@ public class QuestionScreen : MonoBehaviour
     
     public void OnSubmitAnswer()
     {
+        MobileHaptics.MediumImpact();
+
         if (answerInput == null || string.IsNullOrEmpty(answerInput.text))
         {
             Debug.LogWarning("Please enter an answer!");
@@ -365,6 +367,8 @@ public class QuestionScreen : MonoBehaviour
 
     void ShowAnswerError(string message)
     {
+        MobileHaptics.Failure();
+
         Debug.LogError("ANSWER ERROR: " + message);
 
         // Display error message in UI

--- a/Assets/Scripts/round_art_screen_script.cs
+++ b/Assets/Scripts/round_art_screen_script.cs
@@ -98,6 +98,8 @@ public class RoundArtScreen : MonoBehaviour
     
     public void OnContinueClicked()
     {
+        MobileHaptics.MediumImpact();
+
         // Stop auto-advance coroutine
         StopAllCoroutines();
         AdvanceToQuestion();

--- a/Assets/Scripts/round_results_script.cs
+++ b/Assets/Scripts/round_results_script.cs
@@ -733,11 +733,15 @@ public class RoundResultsScreen : MonoBehaviour
     
     public void OnNextRoundClicked()
     {
+        MobileHaptics.MediumImpact();
+
         GameManager.Instance.AdvanceToNextScreen();
     }
 
     public void OnFinalResultsClicked()
     {
+        MobileHaptics.HeavyImpact();
+
         // Load final results screen
         if (SceneTransitionManager.Instance != null)
         {

--- a/Assets/Scripts/voting_screen_script.cs
+++ b/Assets/Scripts/voting_screen_script.cs
@@ -182,6 +182,8 @@ public class VotingScreen : MonoBehaviour
     
     void OnAnswerSelected(string answer, GameObject buttonObj)
     {
+        MobileHaptics.SelectionChanged();
+
         selectedAnswer = answer;
         
         // Visual feedback - highlight selected button
@@ -217,9 +219,12 @@ public class VotingScreen : MonoBehaviour
     
     public void OnSubmitVote()
     {
+        MobileHaptics.MediumImpact();
+
         if (string.IsNullOrEmpty(selectedAnswer))
         {
             Debug.LogWarning("No answer selected!");
+            MobileHaptics.Failure();
             return;
         }
         


### PR DESCRIPTION
## Summary
- add a reusable MobileHaptics helper with Android-specific vibration tuning and cross-platform fallbacks
- trigger light, medium, and heavy haptic feedback for key mobile interactions from landing through final results
- hook error states and selection changes to stronger haptics so mobile players get tactile confirmation throughout the flow

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68e6ff7f8a60832eaebab71b31c44fe5