### PR TITLE
Ensure GameManager spawns as a networked singleton

### DIFF
--- a/Assets/Scripts/core_systems_bootstrapper.cs
+++ b/Assets/Scripts/core_systems_bootstrapper.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using Unity.Netcode;
 
 /// <summary>
 /// Ensures that all core singleton-style systems are present in the scene graph
@@ -67,7 +68,23 @@ public static class CoreSystemsBootstrapper
             Debug.Log($"[CoreSystemsBootstrapper] Creating {managerName}...");
 
         var managerObj = new GameObject(managerName);
-        managerObj.AddComponent<T>();
+        var managerComponent = managerObj.AddComponent<T>();
+
+        if (managerComponent is GameManager)
+        {
+            var networkObject = managerObj.GetComponent<NetworkObject>();
+
+            if (networkObject == null)
+            {
+                networkObject = managerObj.AddComponent<NetworkObject>();
+            }
+
+            if (NetworkManager.Singleton != null && NetworkManager.Singleton.IsServer && !networkObject.IsSpawned)
+            {
+                networkObject.Spawn();
+                Debug.Log("[CoreSystemsBootstrapper] Spawned fallback GameManager NetworkObject");
+            }
+        }
 
         if (ENABLE_DEBUG_LOGS)
             Debug.Log($"[CoreSystemsBootstrapper] ✓ {managerName} created");

--- a/Assets/Scripts/game_manager_script.cs
+++ b/Assets/Scripts/game_manager_script.cs
@@ -10,6 +10,7 @@ using Unity.Collections;
 /// Unity Netcode-based GameManager using NetworkVariables and NetworkLists
 /// Follows Unity Netcode best practices for state synchronization
 /// </summary>
+[RequireComponent(typeof(NetworkObject))]
 public class GameManager : NetworkBehaviour
 {
     // Singleton pattern - only one GameManager exists
@@ -92,6 +93,8 @@ public class GameManager : NetworkBehaviour
         Credits
     }
 
+    private NetworkObject _networkObject;
+
     void Awake()
     {
         // Initialize NetworkLists before NetworkObject spawns
@@ -105,11 +108,63 @@ public class GameManager : NetworkBehaviour
             Instance = this;
             DontDestroyOnLoad(gameObject);
             Debug.Log("[GameManager] Instance created");
+
+            _networkObject = GetComponent<NetworkObject>();
+
+            TrySpawnNetworkObject();
+
+            if (NetworkManager.Singleton != null)
+            {
+                NetworkManager.Singleton.OnServerStarted += HandleServerStarted;
+            }
         }
         else
         {
             Debug.Log("[GameManager] Duplicate found and destroyed");
             Destroy(gameObject);
+        }
+    }
+
+    private void OnDestroy()
+    {
+        if (NetworkManager.Singleton != null)
+        {
+            NetworkManager.Singleton.OnServerStarted -= HandleServerStarted;
+        }
+    }
+
+    private void HandleServerStarted()
+    {
+        TrySpawnNetworkObject();
+    }
+
+    private void TrySpawnNetworkObject()
+    {
+        if (_networkObject == null)
+        {
+            _networkObject = GetComponent<NetworkObject>();
+        }
+
+        if (_networkObject == null)
+        {
+            _networkObject = gameObject.AddComponent<NetworkObject>();
+            Debug.LogWarning("[GameManager] NetworkObject component was missing and has been added at runtime.");
+        }
+
+        if (NetworkManager.Singleton == null)
+        {
+            return;
+        }
+
+        if (!NetworkManager.Singleton.IsServer)
+        {
+            return;
+        }
+
+        if (!_networkObject.IsSpawned)
+        {
+            _networkObject.Spawn();
+            Debug.Log("[GameManager] NetworkObject spawned by host");
         }
     }
 

--- a/Assets/Scripts/network_manager_script.cs
+++ b/Assets/Scripts/network_manager_script.cs
@@ -95,6 +95,24 @@ public class RWMNetworkManager : NetworkBehaviour
         isConnected = true;
         isHost = true;
         OnRoomCreated?.Invoke(roomCode);
+
+        var gameManager = GameManager.Instance;
+
+        if (gameManager == null)
+        {
+            gameManager = FindObjectOfType<GameManager>();
+        }
+
+        if (gameManager != null)
+        {
+            var networkObject = gameManager.GetComponent<NetworkObject>();
+
+            if (networkObject != null && !networkObject.IsSpawned)
+            {
+                networkObject.Spawn();
+                Debug.Log("[NetworkManager] Spawned GameManager NetworkObject on host start");
+            }
+        }
     }
 
     private void OnClientConnected(ulong clientId)


### PR DESCRIPTION
## Summary
- require a NetworkObject on GameManager and spawn it when the host is ready
- keep bootstrap-created GameManager instances consistent by attaching and spawning their NetworkObject
- trigger GameManager spawning from the network manager once the server starts

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ebd529ec10832ea8a4a8fc94a7afc0