### PR TITLE
Align RWM network manager dependencies

### DIFF
--- a/Assets/Scenes/LoadingScreen.unity
+++ b/Assets/Scenes/LoadingScreen.unity
@@ -957,6 +957,7 @@ GameObject:
   - component: {fileID: 2108762730}
   - component: {fileID: 2108762729}
   - component: {fileID: 2108762728}
+  - component: {fileID: 2108762735}
   - component: {fileID: 2108762734}
   m_Layer: 0
   m_Name: Managers
@@ -1089,7 +1090,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 297b91daa75ac644daf3d3719de7bc75, type: 3}
-  m_Name: 
+  m_Name:
   m_EditorClassIdentifier: Assembly-CSharp::GameManager
   gameMode: 0
   currentRound: 0
@@ -1119,6 +1120,23 @@ MonoBehaviour:
   playerQuestions: []
   pictureQuestions: []
   currentGameState: 0
+--- !u!114 &2108762735
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2108762726}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bc1a65fc3a9553c4fbb182dd4e425fcd, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  roomCode:
+  isHost: 0
+  port: 7777
+  isConnected: 0
+  playerId:
 --- !u!114 &2108762734
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/core_systems_bootstrapper.cs
+++ b/Assets/Scripts/core_systems_bootstrapper.cs
@@ -1,4 +1,6 @@
 using UnityEngine;
+using Unity.Netcode;
+using Unity.Netcode.Transports.UTP;
 
 /// <summary>
 /// Ensures that all core singleton-style systems are present in the scene graph
@@ -68,6 +70,24 @@ public static class CoreSystemsBootstrapper
 
         var managerObj = new GameObject(managerName);
         managerObj.AddComponent<T>();
+
+        if (typeof(T) == typeof(RWMNetworkManager))
+        {
+            if (managerObj.GetComponent<NetworkManager>() == null)
+            {
+                managerObj.AddComponent<NetworkManager>();
+            }
+
+            if (managerObj.GetComponent<NetworkObject>() == null)
+            {
+                managerObj.AddComponent<NetworkObject>();
+            }
+
+            if (managerObj.GetComponent<UnityTransport>() == null)
+            {
+                managerObj.AddComponent<UnityTransport>();
+            }
+        }
 
         if (ENABLE_DEBUG_LOGS)
             Debug.Log($"[CoreSystemsBootstrapper] ✓ {managerName} created");

--- a/Assets/Scripts/network_manager_script.cs
+++ b/Assets/Scripts/network_manager_script.cs
@@ -1,6 +1,5 @@
 using UnityEngine;
 using System;
-using System.Collections.Generic;
 using Unity.Netcode;
 using Unity.Netcode.Transports.UTP;
 
@@ -8,6 +7,7 @@ using Unity.Netcode.Transports.UTP;
 /// Unity Netcode-based NetworkManager for RWM multiplayer
 /// Desktop acts as Host (Server + Client), mobile devices connect as Clients
 /// </summary>
+[RequireComponent(typeof(NetworkManager), typeof(NetworkObject), typeof(UnityTransport))]
 public class RWMNetworkManager : NetworkBehaviour
 {
     public static RWMNetworkManager Instance;
@@ -36,6 +36,8 @@ public class RWMNetworkManager : NetworkBehaviour
     public event Action OnConnectionError;
 
     private NetworkManager networkManager;
+    private NetworkObject networkObject;
+    private UnityTransport unityTransport;
 
     void Awake()
     {
@@ -53,20 +55,19 @@ public class RWMNetworkManager : NetworkBehaviour
 
     void Start()
     {
-        // Get or add Unity's NetworkManager component
+        // Cache required networking components that must already exist on this GameObject
         networkManager = GetComponent<NetworkManager>();
-        if (networkManager == null)
+        networkObject = GetComponent<NetworkObject>();
+        unityTransport = GetComponent<UnityTransport>();
+
+        if (networkManager == null || networkObject == null || unityTransport == null)
         {
-            networkManager = gameObject.AddComponent<NetworkManager>();
+            Debug.LogError("[NetworkManager] Missing required networking components.");
+            enabled = false;
+            return;
         }
 
-        // Setup Unity Transport
-        var transport = GetComponent<UnityTransport>();
-        if (transport == null)
-        {
-            transport = gameObject.AddComponent<UnityTransport>();
-            networkManager.NetworkConfig.NetworkTransport = transport;
-        }
+        networkManager.NetworkConfig.NetworkTransport = unityTransport;
 
         // Load or generate player ID
         if (PlayerPrefs.HasKey("PlayerID"))
@@ -94,6 +95,10 @@ public class RWMNetworkManager : NetworkBehaviour
         Debug.Log("[NetworkManager] Server started successfully");
         isConnected = true;
         isHost = true;
+        if (!networkObject.IsSpawned)
+        {
+            networkObject.Spawn();
+        }
         OnRoomCreated?.Invoke(roomCode);
     }
 
@@ -133,8 +138,7 @@ public class RWMNetworkManager : NetworkBehaviour
         GenerateRoomCode();
 
         // Start as Host (Server + Client)
-        var transport = networkManager.GetComponent<UnityTransport>();
-        transport.SetConnectionData("127.0.0.1", port);
+        unityTransport.SetConnectionData("127.0.0.1", port);
 
         bool success = networkManager.StartHost();
 
@@ -170,8 +174,7 @@ public class RWMNetworkManager : NetworkBehaviour
         roomCode = code.ToUpper();
 
         // Set connection data to host's IP
-        var transport = networkManager.GetComponent<UnityTransport>();
-        transport.SetConnectionData(hostIP, port);
+        unityTransport.SetConnectionData(hostIP, port);
 
         // Start as Client
         bool success = networkManager.StartClient();


### PR DESCRIPTION
## Summary
- attach the RWMNetworkManager component to the LoadingScreen bootstrap object so it owns networking components
- cache the existing NetworkManager, NetworkObject, and UnityTransport dependencies and spawn the manager once hosting starts
- ensure the bootstrapper adds the required networking components when creating a fallback manager

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ebd529368c832eb0873cd653bb4dde