### PR TITLE
Update netcode regression audit after fix claim

### DIFF
--- a/QA_NETCODE_REVIEW.md
+++ b/QA_NETCODE_REVIEW.md
@@ -22,3 +22,22 @@
 - Adopt `NetworkSceneManager` for all scene loads (`LoadScene`, `ChangeScene`) so scene transitions are replicated, trackable, and recoverable for late joins.
 - Promote question/answer round payloads to netcode-friendly containers (`NetworkVariable<FixedString>` / `NetworkList<FixedString>`), or push them through server-to-client RPCs, before client UI scripts depend on them.
 - Expose transport configuration (listen address, port, relay allocation if applicable) instead of hard-coding loopback so mobile/remote clients can connect.
+
+## 🔍 Current Audit Findings
+
+### ✅ Fixes Confirmed
+- `RWMNetworkManager.StartHost` now binds the Unity Transport to `0.0.0.0`, allowing remote peers instead of restricting the host to loopback only. 【F:Assets/Scripts/network_manager_script.cs†L151-L160】
+- `CoreSystemsBootstrapper` aborts play mode if the preconfigured `RWMNetworkManager` rig is missing, preventing the old runtime-instantiated singleton that shipped with no NetworkConfig. 【F:Assets/Scripts/core_systems_bootstrapper.cs†L40-L105】
+- `GameManager.LoadScene` delegates to `NetworkManager.SceneManager`, so authoritative scene changes replicate through Netcode rather than using the local `SceneManager`. 【F:Assets/Scripts/game_manager_script.cs†L1258-L1280】
+
+### ⚠️ Outstanding Netcode Regressions *(re-verified 2025-10-13 after fix claim)*
+Despite the renewed claim that all regressions were fixed, the latest re-audit confirms the following issues are still present in the live scripts:
+1. **Client-side score patches still bypass Netcode containers.** `RWMNetworkManager.UpdateScoreClientRpc` writes directly into `GameManager.Instance.players[...]`, but that accessor rebuilds a fresh dictionary on every call, so the assignment never touches the authoritative `NetworkList`. Clients that rely on the event receive no persistent score change. 【F:Assets/Scripts/network_manager_script.cs†L429-L444】【F:Assets/Scripts/game_manager_script.cs†L1117-L1129】
+2. **UI resets ignore server authority.** The Credits screen resets `currentRound`, `isHalftimePlayed`, and `isBonusRoundPlayed` by assigning to the `NetworkVariable` wrappers and tries to clear the ephemeral `players` dictionary. None of those calls execute through the server, so nothing actually synchronizes to clients. 【F:Assets/Scripts/credits_screen_script.cs†L108-L123】【F:Assets/Scripts/game_manager_script.cs†L24-L47】【F:Assets/Scripts/game_manager_script.cs†L1117-L1129】
+3. **Developer debug tools still mutate desynced copies.** `DebugManager.ClearAllPlayers` and related helpers operate on the same transient dictionary and set `correctAnswer`/`robotAnswer` as if they were strings, contradicting the new `NetworkVariable<FixedString>` fields. These utilities no longer behave as intended and encourage patterns that skip RPC/NetworkVariable writes. 【F:Assets/Scripts/debug_manager_script.cs†L309-L377】【F:Assets/Scripts/game_manager_script.cs†L41-L47】【F:Assets/Scripts/game_manager_script.cs†L479-L480】
+4. **Scene jumps outside Netcode remain.** `PlayerQuestionVideoScript.AdvanceToNextScreen` still calls `SceneTransitionManager` (which falls back to `SceneManager.LoadScene`), so the host loads the Question scene locally without Netcode scene events when the player question video ends. This recreates the original desync for late joiners. 【F:Assets/Scripts/player_question_video_script.cs†L127-L140】【F:Assets/Scripts/scene_transition_manager.cs†L94-L133】
+
+### ▶️ Next Steps
+- Route all score, timer, and state resets through server-side `GameManager` helpers that touch the underlying `NetworkList`/`NetworkVariable` instances instead of modifying the compatibility dictionary.
+- Replace any remaining direct `SceneManager`/`SceneTransitionManager` calls in gameplay flows with `GameManager.LoadScene` (or explicit `NetworkSceneManager` calls) so scene history remains authoritative.
+- Update debug utilities to issue RPCs or invoke `GameManager` server methods; otherwise keep them editor-only to avoid misleading runtime workflows.


### PR DESCRIPTION
## Summary
- update QA_NETCODE_REVIEW.md to record the 2025-10-13 re-verification following the latest fix claim
- reaffirm that the four previously documented netcode regressions remain present in the live scripts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ebe4b4aa68832e989f33c2b148d065

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Current Audit Findings” section summarizing confirmed fixes, outstanding issues, and actionable next steps.
  * Augmented high-level recommendations with concrete audit results for improved clarity.
  * Improved visibility into current status and priorities to aid QA and development planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->