### PR TITLE
Ensure host-only scene progression for Netcode

### DIFF
--- a/Assets/Scripts/bonus_intro_script.cs
+++ b/Assets/Scripts/bonus_intro_script.cs
@@ -65,7 +65,14 @@ public class BonusIntroScreen : MonoBehaviour
     
     void AdvanceToBonusQuestions()
     {
-        GameManager.Instance.AdvanceToNextScreen();
+        if (GameManager.Instance != null && GameManager.Instance.IsServer)
+        {
+            GameManager.Instance.AdvanceToNextScreen();
+        }
+        else
+        {
+            Debug.LogWarning("[BonusIntroScreen] Only the host can advance to the next screen.");
+        }
     }
     
     void OnDestroy()

--- a/Assets/Scripts/bonus_results_script.cs
+++ b/Assets/Scripts/bonus_results_script.cs
@@ -193,7 +193,14 @@ public class BonusResultsScreen : MonoBehaviour
         MobileHaptics.MediumImpact();
 
         // Continue to next round (Round 5 for 8Q, Round 7 for 12Q)
-        GameManager.Instance.AdvanceToNextScreen();
+        if (GameManager.Instance != null && GameManager.Instance.IsServer)
+        {
+            GameManager.Instance.AdvanceToNextScreen();
+        }
+        else
+        {
+            Debug.LogWarning("[BonusResults] Only the host can advance to the next screen.");
+        }
     }
     
     string GetLocalPlayerID()

--- a/Assets/Scripts/debug_manager_script.cs
+++ b/Assets/Scripts/debug_manager_script.cs
@@ -123,40 +123,40 @@ public class DebugManager : MonoBehaviour
         
         // === SCENE JUMPING ===
         GUILayout.Label("=== SCENE NAVIGATION ===");
-        
+
         if (GUILayout.Button("Landing Screen"))
         {
-            SceneManager.LoadScene("LandingScreen");
+            TryLoadScene("LandingScreen");
         }
-        
+
         if (GUILayout.Button("Lobby Screen"))
         {
-            SceneManager.LoadScene("LobbyScreen");
+            TryLoadScene("LobbyScreen");
         }
-        
+
         if (GUILayout.Button("Question Screen"))
         {
-            SceneManager.LoadScene("QuestionScreen");
+            TryLoadScene("QuestionScreen");
         }
-        
+
         if (GUILayout.Button("Elimination Screen"))
         {
-            SceneManager.LoadScene("EliminationScreen");
+            TryLoadScene("EliminationScreen");
         }
-        
+
         if (GUILayout.Button("Voting Screen"))
         {
-            SceneManager.LoadScene("VotingScreen");
+            TryLoadScene("VotingScreen");
         }
-        
+
         if (GUILayout.Button("Results Screen"))
         {
-            SceneManager.LoadScene("ResultsScreen");
+            TryLoadScene("ResultsScreen");
         }
-        
+
         if (GUILayout.Button("Final Results"))
         {
-            SceneManager.LoadScene("FinalResults");
+            TryLoadScene("FinalResults");
         }
         
         GUILayout.Space(10);
@@ -177,8 +177,11 @@ public class DebugManager : MonoBehaviour
         
         if (GUILayout.Button("Next Round"))
         {
-            GameManager.Instance.currentRound++;
-            GameManager.Instance.AdvanceToNextScreen();
+            if (EnsureServerAuthority("advance to the next round"))
+            {
+                GameManager.Instance.currentRound.Value++;
+                GameManager.Instance.AdvanceToNextScreen();
+            }
         }
         
         GUILayout.Space(10);
@@ -248,25 +251,17 @@ public class DebugManager : MonoBehaviour
         
         if (GUILayout.Button("Set Timer to 5 seconds"))
         {
-            if (GameManager.Instance.IsServer)
+            if (EnsureServerAuthority("set the timer to 5 seconds"))
             {
                 GameManager.Instance.currentTimerValue.Value = 5f;
-            }
-            else
-            {
-                Debug.LogWarning("[DebugManager] Only server can modify timer");
             }
         }
 
         if (GUILayout.Button("Skip Timer"))
         {
-            if (GameManager.Instance.IsServer)
+            if (EnsureServerAuthority("skip the timer"))
             {
                 GameManager.Instance.currentTimerValue.Value = 0f;
-            }
-            else
-            {
-                Debug.LogWarning("[DebugManager] Only server can modify timer");
             }
         }
 
@@ -277,35 +272,52 @@ public class DebugManager : MonoBehaviour
 
         if (GUILayout.Button("Switch to 8Q Mode"))
         {
-            if (GameManager.Instance.IsServer)
+            if (EnsureServerAuthority("switch to 8Q mode"))
             {
                 GameManager.Instance.gameMode.Value = GameManager.GameMode.EightQuestions;
-            }
-            else
-            {
-                Debug.LogWarning("[DebugManager] Only server can modify game mode");
             }
         }
 
         if (GUILayout.Button("Switch to 12Q Mode"))
         {
-            if (GameManager.Instance.IsServer)
+            if (EnsureServerAuthority("switch to 12Q mode"))
             {
                 GameManager.Instance.gameMode.Value = GameManager.GameMode.TwelveQuestions;
-            }
-            else
-            {
-                Debug.LogWarning("[DebugManager] Only server can modify game mode");
             }
         }
         
         GUILayout.EndScrollView();
-        
+
         GUI.DragWindow();
     }
-    
+
+    bool EnsureServerAuthority(string action)
+    {
+        if (GameManager.Instance == null)
+        {
+            Debug.LogWarning($"[DebugManager] Cannot {action}: GameManager is not available.");
+            return false;
+        }
+
+        if (!GameManager.Instance.IsServer)
+        {
+            Debug.LogWarning($"[DebugManager] Cannot {action}: host authority required.");
+            return false;
+        }
+
+        return true;
+    }
+
+    void TryLoadScene(string sceneName)
+    {
+        if (EnsureServerAuthority($"load scene {sceneName}"))
+        {
+            GameManager.Instance.LoadScene(sceneName);
+        }
+    }
+
     // === DEBUG FUNCTIONS ===
-    
+
     public void AddTestPlayers()
     {
         if (!GameManager.Instance.IsServer)
@@ -361,8 +373,7 @@ public class DebugManager : MonoBehaviour
     
     public void ClearAllPlayers()
     {
-        // Use server-authoritative method
-        if (GameManager.Instance != null)
+        if (EnsureServerAuthority("clear all players"))
         {
             GameManager.Instance.ClearAllPlayers();
         }
@@ -370,11 +381,7 @@ public class DebugManager : MonoBehaviour
 
     public void SimulateAllAnswers()
     {
-        if (!GameManager.Instance.IsServer)
-        {
-            Debug.LogWarning("[DebugManager] Only server can simulate answers");
-            return;
-        }
+        if (!EnsureServerAuthority("simulate answers")) return;
 
         string[] sampleAnswers = new string[]
         {
@@ -410,9 +417,11 @@ public class DebugManager : MonoBehaviour
 
         Debug.Log("Simulated answers for all players");
     }
-    
+
     public void SimulateRandomVotes()
     {
+        if (!EnsureServerAuthority("simulate votes")) return;
+
         List<string> answers;
 
         // Use appropriate answer list based on current screen
@@ -473,6 +482,8 @@ public class DebugManager : MonoBehaviour
 
     public void SimulateBonusVotes()
     {
+        if (!EnsureServerAuthority("simulate bonus votes")) return;
+
         // Get all players
         List<PlayerData> allPlayers = GameManager.Instance.GetAllPlayers();
 
@@ -493,14 +504,19 @@ public class DebugManager : MonoBehaviour
 
         Debug.Log("Simulated bonus votes for all players");
     }
-    
+
     public void AutoCompleteRound()
     {
-        StartCoroutine(AutoCompleteRoundCoroutine());
+        if (EnsureServerAuthority("auto-complete the round"))
+        {
+            StartCoroutine(AutoCompleteRoundCoroutine());
+        }
     }
 
     System.Collections.IEnumerator AutoCompleteRoundCoroutine()
     {
+        if (!EnsureServerAuthority("auto-complete the round")) yield break;
+
         // Simulate entire round automatically
         SimulateAllAnswers();
         yield return new WaitForSeconds(0.5f);
@@ -518,25 +534,20 @@ public class DebugManager : MonoBehaviour
 
         Debug.Log("Auto-completed round");
     }
-    
+
     public void SkipToRound(int round)
     {
-        if (GameManager.Instance.IsServer)
+        if (EnsureServerAuthority($"skip to round {round}"))
         {
             GameManager.Instance.currentRound.Value = round - 1;
             GameManager.Instance.AdvanceToNextScreen();
             Debug.Log("Skipped to round " + round);
         }
-        else
-        {
-            Debug.LogWarning("[DebugManager] Only server can skip rounds");
-        }
     }
 
     public void AddPointsToAllPlayers(int points)
     {
-        // Use server-authoritative method
-        if (GameManager.Instance != null)
+        if (EnsureServerAuthority("add points to all players"))
         {
             GameManager.Instance.AddPointsToAllPlayers(points);
         }
@@ -544,8 +555,7 @@ public class DebugManager : MonoBehaviour
 
     public void ResetAllScores()
     {
-        // Use server-authoritative method
-        if (GameManager.Instance != null)
+        if (EnsureServerAuthority("reset all player scores"))
         {
             GameManager.Instance.ResetAllPlayerScores();
         }
@@ -553,7 +563,7 @@ public class DebugManager : MonoBehaviour
 
     public void RandomizeScores()
     {
-        if (GameManager.Instance != null && GameManager.Instance.IsServer)
+        if (EnsureServerAuthority("randomize scores"))
         {
             // Directly manipulate NetworkList on server
             for (int i = 0; i < GameManager.Instance.networkPlayers.Count; i++)
@@ -564,22 +574,14 @@ public class DebugManager : MonoBehaviour
             }
             Debug.Log("Randomized all player scores");
         }
-        else
-        {
-            Debug.LogWarning("[DebugManager] Only server can randomize scores");
-        }
     }
-    
+
     public void ToggleTimer()
     {
-        if (GameManager.Instance.IsServer)
+        if (EnsureServerAuthority("toggle the timer"))
         {
             GameManager.Instance.timerActive.Value = !GameManager.Instance.timerActive.Value;
             Debug.Log("Timer " + (GameManager.Instance.timerActive.Value ? "resumed" : "paused"));
-        }
-        else
-        {
-            Debug.LogWarning("[DebugManager] Only server can toggle timer");
         }
     }
     

--- a/Assets/Scripts/halftime_results_script.cs
+++ b/Assets/Scripts/halftime_results_script.cs
@@ -149,7 +149,14 @@ public class HalftimeResultsScreen : MonoBehaviour
         else
         {
             // Both panels shown, advance to next screen
-            GameManager.Instance.AdvanceToNextScreen();
+            if (GameManager.Instance != null && GameManager.Instance.IsServer)
+            {
+                GameManager.Instance.AdvanceToNextScreen();
+            }
+            else
+            {
+                Debug.LogWarning("[HalftimeResults] Only the host can advance to the next screen.");
+            }
         }
     }
     
@@ -354,7 +361,14 @@ public class HalftimeResultsScreen : MonoBehaviour
         MobileHaptics.MediumImpact();
 
         // Continue to Bonus Round
-        GameManager.Instance.AdvanceToNextScreen();
+        if (GameManager.Instance != null && GameManager.Instance.IsServer)
+        {
+            GameManager.Instance.AdvanceToNextScreen();
+        }
+        else
+        {
+            Debug.LogWarning("[HalftimeResults] Only the host can advance to the next screen.");
+        }
     }
     
     string GetLocalPlayerID()

--- a/Assets/Scripts/landing_screen_script.cs
+++ b/Assets/Scripts/landing_screen_script.cs
@@ -69,7 +69,14 @@ public class LandingScreen : MonoBehaviour
             return;
         }
 
-        GameManager.Instance.AdvanceToNextScreen();
+        if (GameManager.Instance != null && GameManager.Instance.IsServer)
+        {
+            GameManager.Instance.AdvanceToNextScreen();
+        }
+        else
+        {
+            Debug.LogWarning("[LandingScreen] Only the host can advance to the next screen.");
+        }
     }
 
     public void OnJoinGameClicked()
@@ -85,7 +92,14 @@ public class LandingScreen : MonoBehaviour
             return;
         }
 
-        GameManager.Instance.AdvanceToNextScreen();
+        if (GameManager.Instance != null && GameManager.Instance.IsServer)
+        {
+            GameManager.Instance.AdvanceToNextScreen();
+        }
+        else
+        {
+            Debug.LogWarning("[LandingScreen] Only the host can advance to the next screen.");
+        }
     }
     
     void OnVideoPrepared(VideoPlayer source)

--- a/Assets/Scripts/lobby_screen_script.cs
+++ b/Assets/Scripts/lobby_screen_script.cs
@@ -377,7 +377,14 @@ public class LobbyScreen : MonoBehaviour
         Debug.Log("Start button clicked - currentGameState: " + GameManager.Instance.currentGameState + ", currentRound: " + GameManager.Instance.currentRound);
 
         // Advance to Round Art (which will load Round 1)
-        GameManager.Instance.AdvanceToNextScreen();
+        if (GameManager.Instance != null && GameManager.Instance.IsServer)
+        {
+            GameManager.Instance.AdvanceToNextScreen();
+        }
+        else
+        {
+            Debug.LogWarning("[LobbyScreen] Only the host can start the game.");
+        }
     }
 
     // === MOBILE JOIN FORM ===

--- a/Assets/Scripts/networked_player.cs
+++ b/Assets/Scripts/networked_player.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using Unity.Netcode;
+using Unity.Collections;
 using System;
 
 /// <summary>

--- a/Assets/Scripts/round_art_screen_script.cs
+++ b/Assets/Scripts/round_art_screen_script.cs
@@ -136,7 +136,14 @@ public class RoundArtScreen : MonoBehaviour
     
     void AdvanceToQuestion()
     {
-        GameManager.Instance.AdvanceToNextScreen();
+        if (GameManager.Instance != null && GameManager.Instance.IsServer)
+        {
+            GameManager.Instance.AdvanceToNextScreen();
+        }
+        else
+        {
+            Debug.LogWarning("[RoundArtScreen] Only the host can advance to the next screen.");
+        }
     }
     
     void OnDestroy()

--- a/Assets/Scripts/round_results_script.cs
+++ b/Assets/Scripts/round_results_script.cs
@@ -188,7 +188,14 @@ public class RoundResultsScreen : MonoBehaviour
         else
         {
             // All panels shown, advance to next screen
-            GameManager.Instance.AdvanceToNextScreen();
+            if (GameManager.Instance != null && GameManager.Instance.IsServer)
+            {
+                GameManager.Instance.AdvanceToNextScreen();
+            }
+            else
+            {
+                Debug.LogWarning("[RoundResults] Only the host can advance to the next screen.");
+            }
         }
     }
     
@@ -735,7 +742,14 @@ public class RoundResultsScreen : MonoBehaviour
     {
         MobileHaptics.MediumImpact();
 
-        GameManager.Instance.AdvanceToNextScreen();
+        if (GameManager.Instance != null && GameManager.Instance.IsServer)
+        {
+            GameManager.Instance.AdvanceToNextScreen();
+        }
+        else
+        {
+            Debug.LogWarning("[RoundResults] Only the host can advance to the next screen.");
+        }
     }
 
     public void OnFinalResultsClicked()


### PR DESCRIPTION
## Summary
- guard UI flows such as landing, lobby, bonus, halftime, and results screens so only the server advances scenes and clients receive clear warnings
- refactor the debug manager to respect Netcode authority by routing scene loads through NetworkSceneManager helpers and centralizing host-only checks
- add the missing Unity.Collections import for networked player data structures

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ebe7f1c128832e843d215d2a4759f2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added host-only control for advancing game screens; non-host clients can no longer progress the flow.
- Bug Fixes
  - Prevented unintended screen navigation by non-host players across landing, lobby, halftime, round results, bonus, and art screens.
- Improvements
  - Applied consistent host checks to continue/next actions for greater multiplayer reliability.
  - Enhanced debug tools with authorization safeguards and safer scene transitions to avoid accidental state changes by non-hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->