### PR TITLE
Expose read-only vote data for netcode UI

### DIFF
--- a/Assets/Scripts/bonus_question_script.cs
+++ b/Assets/Scripts/bonus_question_script.cs
@@ -422,7 +422,7 @@ public class BonusQuestionScreen : MonoBehaviour
     {
         // Update icon appearance for players who have voted
         List<PlayerData> allPlayers = GameManager.Instance.GetAllPlayers();
-        var bonusVotes = GameManager.Instance.bonusVotes;
+        var bonusVotes = GameManager.Instance.BonusVotes;
 
         for (int i = 0; i < allPlayers.Count && i < spawnedPlayerIcons.Count; i++)
         {

--- a/Assets/Scripts/game_manager_script.cs
+++ b/Assets/Scripts/game_manager_script.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Unity.Netcode;
 using Unity.Collections;
@@ -31,10 +32,15 @@ public class GameManager : NetworkBehaviour
     public NetworkList<NetworkedPlayerData> networkPlayers; // Replaces Dictionary
 
     // Temporary dictionaries for compatibility during transition (server-only)
-    private Dictionary<string, string> currentRoundAnswers = new Dictionary<string, string>();
-    private Dictionary<string, string> eliminationVotes = new Dictionary<string, string>();
-    private Dictionary<string, string> votingVotes = new Dictionary<string, string>();
-    private Dictionary<string, string> bonusVotes = new Dictionary<string, string>();
+    private readonly Dictionary<string, string> currentRoundAnswers = new Dictionary<string, string>();
+    private readonly Dictionary<string, string> eliminationVotes = new Dictionary<string, string>();
+    private readonly Dictionary<string, string> votingVotes = new Dictionary<string, string>();
+    private readonly Dictionary<string, string> bonusVotes = new Dictionary<string, string>();
+
+    private ReadOnlyDictionary<string, string> readOnlyCurrentRoundAnswers;
+    private ReadOnlyDictionary<string, string> readOnlyEliminationVotes;
+    private ReadOnlyDictionary<string, string> readOnlyVotingVotes;
+    private ReadOnlyDictionary<string, string> readOnlyBonusVotes;
 
     // === ROUND DATA ===
     [Header("Current Round Data")]
@@ -105,6 +111,12 @@ public class GameManager : NetworkBehaviour
         networkPlayers = new NetworkList<NetworkedPlayerData>();
         allAnswers = new NetworkList<FixedString128Bytes>();
         remainingAnswers = new NetworkList<FixedString128Bytes>();
+
+        // Initialize read-only wrappers for server dictionaries used by UI code
+        readOnlyCurrentRoundAnswers = new ReadOnlyDictionary<string, string>(currentRoundAnswers);
+        readOnlyEliminationVotes = new ReadOnlyDictionary<string, string>(eliminationVotes);
+        readOnlyVotingVotes = new ReadOnlyDictionary<string, string>(votingVotes);
+        readOnlyBonusVotes = new ReadOnlyDictionary<string, string>(bonusVotes);
 
         // Singleton setup
         if (Instance == null)
@@ -1130,6 +1142,32 @@ public class GameManager : NetworkBehaviour
     {
         List<PlayerData> allPlayers = GetAllPlayers();
         return allPlayers.OrderByDescending(p => p.scorePercentage).ToList();
+    }
+
+    // Read-only accessors for server-maintained dictionaries so UI can query submission state without modifying data
+    public IReadOnlyDictionary<string, string> CurrentRoundAnswers => readOnlyCurrentRoundAnswers;
+    public IReadOnlyDictionary<string, string> EliminationVotes => readOnlyEliminationVotes;
+    public IReadOnlyDictionary<string, string> VotingVotes => readOnlyVotingVotes;
+    public IReadOnlyDictionary<string, string> BonusVotes => readOnlyBonusVotes;
+
+    public bool HasPlayerSubmittedAnswer(string playerID)
+    {
+        return currentRoundAnswers.ContainsKey(playerID);
+    }
+
+    public bool TryGetPlayerAnswer(string playerID, out string answer)
+    {
+        return currentRoundAnswers.TryGetValue(playerID, out answer);
+    }
+
+    public bool TryGetVotingVote(string playerID, out string votedAnswer)
+    {
+        return votingVotes.TryGetValue(playerID, out votedAnswer);
+    }
+
+    public bool TryGetBonusVote(string playerID, out string votedPlayerID)
+    {
+        return bonusVotes.TryGetValue(playerID, out votedPlayerID);
     }
 
     // Compatibility property for old Dictionary access pattern

--- a/Assets/Scripts/picture_question_script.cs
+++ b/Assets/Scripts/picture_question_script.cs
@@ -195,7 +195,7 @@ public class PictureQuestionScreen : MonoBehaviour
             PlayerData player = players[i];
 
             // Check if this player has submitted an answer
-            bool hasSubmitted = GameManager.Instance.currentRoundAnswers.ContainsKey(player.playerID);
+            bool hasSubmitted = GameManager.Instance.HasPlayerSubmittedAnswer(player.playerID);
 
             // Show/hide entire icon based on submission (matching regular Questions behavior)
             iconObj.SetActive(hasSubmitted);

--- a/Assets/Scripts/question_screen_script.cs
+++ b/Assets/Scripts/question_screen_script.cs
@@ -396,7 +396,7 @@ public class QuestionScreen : MonoBehaviour
             PlayerData player = players[i];
 
             // Check if this player has submitted an answer
-            bool hasSubmitted = GameManager.Instance.currentRoundAnswers.ContainsKey(player.playerID);
+            bool hasSubmitted = GameManager.Instance.HasPlayerSubmittedAnswer(player.playerID);
 
             // Check previous state
             bool wasActive = iconObj.activeSelf;

--- a/Assets/Scripts/round_results_script.cs
+++ b/Assets/Scripts/round_results_script.cs
@@ -344,7 +344,7 @@ public class RoundResultsScreen : MonoBehaviour
         }
 
         // Get voting results
-        var votingVotes = GameManager.Instance.votingVotes;
+        var votingVotes = GameManager.Instance.VotingVotes;
         List<PlayerData> allPlayers = GameManager.Instance.GetAllPlayers();
 
         int trueCount = 0, robotCount = 0, otherCount = 0;
@@ -454,7 +454,7 @@ public class RoundResultsScreen : MonoBehaviour
         }
 
         // Get player answers and voting results
-        var playerAnswers = GameManager.Instance.currentRoundAnswers;
+        var playerAnswers = GameManager.Instance.CurrentRoundAnswers;
         var votingResults = GameManager.Instance.GetVotingResults();
         List<PlayerData> allPlayers = GameManager.Instance.GetAllPlayers();
 


### PR DESCRIPTION
## Summary
- wrap server-only answer and vote dictionaries in read-only accessors to preserve authority while allowing UI queries
- update round, question, picture, and bonus screens to use the new GameManager API when checking submission or vote status

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ebeaa18fc4832e820699ee577957c5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Unified how answer and vote data are read across game screens using centralized, read-only sources.
  - Updated player status indicators to use a single submission check, preserving existing UI behavior.
  - Standardized access for results panels, ensuring consistent display of votes and answers.
  - Improved data safety by preventing unintended modifications from UI scripts, enhancing overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->