### PR TITLE
Use NetworkVariable values when logging game state

### DIFF
--- a/Assets/Scripts/debug_manager_script.cs
+++ b/Assets/Scripts/debug_manager_script.cs
@@ -114,8 +114,8 @@ public class DebugManager : MonoBehaviour
         scrollPosition = GUILayout.BeginScrollView(scrollPosition);
         
         GUILayout.Label("=== GAME STATE ===");
-        GUILayout.Label("Current Round: " + GameManager.Instance.currentRound);
-        GUILayout.Label("Game Mode: " + GameManager.Instance.gameMode);
+        GUILayout.Label("Current Round: " + GameManager.Instance.currentRound.Value);
+        GUILayout.Label("Game Mode: " + GameManager.Instance.gameMode.Value);
         GUILayout.Label("Players: " + GameManager.Instance.GetAllPlayers().Count);
         GUILayout.Label("Timer: " + GameManager.Instance.GetTimerDisplay());
         
@@ -597,8 +597,8 @@ public class DebugManager : MonoBehaviour
     public void LogGameState()
     {
         Debug.Log("=== GAME STATE ===");
-        Debug.Log("Round: " + GameManager.Instance.currentRound);
-        Debug.Log("Mode: " + GameManager.Instance.gameMode);
+        Debug.Log("Round: " + GameManager.Instance.currentRound.Value);
+        Debug.Log("Mode: " + GameManager.Instance.gameMode.Value);
         Debug.Log("Players: " + GameManager.Instance.GetAllPlayers().Count);
         Debug.Log("Timer: " + GameManager.Instance.GetTimeRemaining() + "s");
         Debug.Log("Current Scene: " + SceneManager.GetActiveScene().name);

--- a/Assets/Scripts/lobby_screen_script.cs
+++ b/Assets/Scripts/lobby_screen_script.cs
@@ -374,7 +374,7 @@ public class LobbyScreen : MonoBehaviour
             return;
         }
 
-        Debug.Log("Start button clicked - currentGameState: " + GameManager.Instance.currentGameState + ", currentRound: " + GameManager.Instance.currentRound);
+        Debug.Log("Start button clicked - currentGameState: " + GameManager.Instance.currentGameState.Value + ", currentRound: " + GameManager.Instance.currentRound.Value);
 
         // Advance to Round Art (which will load Round 1)
         if (GameManager.Instance != null && GameManager.Instance.IsServer)
@@ -798,7 +798,7 @@ public class LobbyScreen : MonoBehaviour
                 (RWMNetworkManager.Instance != null ? RWMNetworkManager.Instance.GetRoomCode() : "");
 
             waitData.text = nonHostPlayerCount + " Players\n" +
-                           (GameManager.Instance.gameMode == GameManager.GameMode.EightQuestions ? "8" : "12") + " Questions\n" +
+                           (GameManager.Instance.gameMode.Value == GameManager.GameMode.EightQuestions ? "8" : "12") + " Questions\n" +
                            displayRoomCode;
         }
 

--- a/Assets/Scripts/round_art_screen_script.cs
+++ b/Assets/Scripts/round_art_screen_script.cs
@@ -54,7 +54,7 @@ public class RoundArtScreen : MonoBehaviour
     
     void ShowRoundBackground()
     {
-        Debug.Log("ShowRoundBackground - Direct access to GameManager.Instance.currentRound: " + GameManager.Instance.currentRound);
+        Debug.Log("ShowRoundBackground - Direct access to GameManager.Instance.currentRound: " + GameManager.Instance.currentRound.Value);
 
         int currentRound = GameManager.Instance.GetCurrentRound();
         bool isMobile = DeviceDetector.Instance != null && DeviceDetector.Instance.IsMobile();

--- a/Assets/Scripts/round_results_script.cs
+++ b/Assets/Scripts/round_results_script.cs
@@ -723,7 +723,7 @@ public class RoundResultsScreen : MonoBehaviour
     void UpdateNavigationButtons()
     {
         int currentRound = GameManager.Instance.GetCurrentRound();
-        int totalRounds = (GameManager.Instance.gameMode == GameManager.GameMode.EightQuestions) ? 8 : 12;
+        int totalRounds = (GameManager.Instance.gameMode.Value == GameManager.GameMode.EightQuestions) ? 8 : 12;
         
         bool isLastRound = currentRound >= totalRounds;
         


### PR DESCRIPTION
## Summary
- use the NetworkVariable.Value property when logging game state in the lobby and debug tools
- update the mobile lobby wait text to read the synchronized game mode value
- ensure round art and results screens log the replicated round value instead of the wrapper object

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ebed127bec832ebbea9fea74cefa8e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected round and game mode values displayed in the Debug Window and logs.
  - Fixed lobby UI to show the correct game mode and round in Start Game actions and the “Questions” line.
  - Ensured navigation buttons accurately reflect the last round based on the selected game mode.
  - Improved round background screen debug output to report the correct current round.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->