### PR TITLE
Ensure netcode state sync across gameplay screens

### DIFF
--- a/Assets/Scripts/bonus_question_script.cs
+++ b/Assets/Scripts/bonus_question_script.cs
@@ -71,7 +71,7 @@ public class BonusQuestionScreen : MonoBehaviour
 
     void InitializeBonusQuestion()
     {
-        Debug.Log("InitializeBonusQuestion called for question index: " + GameManager.Instance.currentBonusQuestion);
+        Debug.Log("InitializeBonusQuestion called for question index: " + GameManager.Instance.currentBonusQuestion.Value);
 
         // Display current bonus question
         DisplayBonusQuestion();
@@ -121,7 +121,7 @@ public class BonusQuestionScreen : MonoBehaviour
     void Update()
     {
         // Check if we moved to next bonus question
-        int currentQuestionIndex = GameManager.Instance.currentBonusQuestion;
+        int currentQuestionIndex = GameManager.Instance.currentBonusQuestion.Value;
         int totalBonusQuestions = GameManager.Instance.GetBonusQuestionCount();
         if (currentQuestionIndex != lastBonusQuestionIndex && lastBonusQuestionIndex != -1 && currentQuestionIndex < totalBonusQuestions)
         {
@@ -170,7 +170,7 @@ public class BonusQuestionScreen : MonoBehaviour
         }
 
         // Show question number (1/4, 2/4, etc.)
-        int questionNum = GameManager.Instance.currentBonusQuestion + 1;
+        int questionNum = GameManager.Instance.currentBonusQuestion.Value + 1;
         int totalQuestions = GameManager.Instance.GetBonusQuestionCount();
         Debug.Log("Bonus Question " + questionNum + "/" + totalQuestions);
     }

--- a/Assets/Scripts/game_manager_script.cs
+++ b/Assets/Scripts/game_manager_script.cs
@@ -386,7 +386,11 @@ public class GameManager : NetworkBehaviour
                 if (currentBonusQuestion.Value < totalBonusQuestions)
                 {
                     Debug.Log($"[GameManager] Continuing to bonus question {currentBonusQuestion.Value}");
-                    bonusVotes.Clear();
+                    ClearBonusVotesLocal();
+                    if (IsSpawned)
+                    {
+                        ClearBonusVotesClientRpc();
+                    }
                     StartTimer(votingTimer);
                 }
                 else
@@ -471,13 +475,59 @@ public class GameManager : NetworkBehaviour
                 break;
         }
 
-        // Clear previous round data
-        currentRoundAnswers.Clear();
-        eliminationVotes.Clear();
-        votingVotes.Clear();
+        // Clear previous round data and notify clients so cached submissions don't leak between rounds
+        ClearSubmissionCachesLocal();
+        if (IsSpawned)
+        {
+            ClearSubmissionCachesClientRpc();
+        }
+
         allAnswers.Clear();
         remainingAnswers.Clear();
         eliminatedAnswer.Value = "";
+    }
+
+    private void ClearSubmissionCachesLocal()
+    {
+        currentRoundAnswers.Clear();
+        eliminationVotes.Clear();
+        votingVotes.Clear();
+        bonusVotes.Clear();
+    }
+
+    [ClientRpc]
+    private void ClearSubmissionCachesClientRpc()
+    {
+        if (IsServer)
+        {
+            return;
+        }
+
+        ClearSubmissionCachesLocal();
+    }
+
+    private void ClearBonusVotesLocal()
+    {
+        bonusVotes.Clear();
+    }
+
+    [ClientRpc]
+    private void ClearBonusVotesClientRpc()
+    {
+        if (IsServer)
+        {
+            return;
+        }
+
+        ClearBonusVotesLocal();
+    }
+
+    private void RemovePlayerFromCaches(string playerID)
+    {
+        currentRoundAnswers.Remove(playerID);
+        eliminationVotes.Remove(playerID);
+        votingVotes.Remove(playerID);
+        bonusVotes.Remove(playerID);
     }
 
     void SyncQuestionData(Question question)
@@ -636,12 +686,9 @@ public class GameManager : NetworkBehaviour
 
     public void SubmitPlayerAnswer(string playerID, string answer)
     {
-        if (!IsServer) return;
+        currentRoundAnswers[playerID] = answer;
 
-        if (!currentRoundAnswers.ContainsKey(playerID))
-        {
-            currentRoundAnswers.Add(playerID, answer);
-        }
+        if (!IsServer) return;
 
         // Check if all players have submitted
         if (currentRoundAnswers.Count >= networkPlayers.Count)
@@ -655,16 +702,9 @@ public class GameManager : NetworkBehaviour
 
     public void SubmitEliminationVote(string playerID, string votedAnswer)
     {
-        if (!IsServer) return;
+        eliminationVotes[playerID] = votedAnswer;
 
-        if (!eliminationVotes.ContainsKey(playerID))
-        {
-            eliminationVotes.Add(playerID, votedAnswer);
-        }
-        else
-        {
-            eliminationVotes[playerID] = votedAnswer;
-        }
+        if (!IsServer) return;
 
         // Check if all players have voted
         if (eliminationVotes.Count >= networkPlayers.Count)
@@ -747,16 +787,9 @@ public class GameManager : NetworkBehaviour
 
     public void SubmitVotingVote(string playerID, string votedAnswer)
     {
-        if (!IsServer) return;
+        votingVotes[playerID] = votedAnswer;
 
-        if (!votingVotes.ContainsKey(playerID))
-        {
-            votingVotes.Add(playerID, votedAnswer);
-        }
-        else
-        {
-            votingVotes[playerID] = votedAnswer;
-        }
+        if (!IsServer) return;
 
         // Check if all players have voted
         if (votingVotes.Count >= networkPlayers.Count)
@@ -832,19 +865,11 @@ public class GameManager : NetworkBehaviour
 
     public void SubmitBonusVote(string playerID, string votedPlayerID)
     {
+        bonusVotes[playerID] = votedPlayerID;
+
         if (!IsServer) return;
 
         Debug.Log($"[GameManager] SubmitBonusVote: player {playerID} voted for {votedPlayerID} (question {currentBonusQuestion.Value})");
-
-        if (!bonusVotes.ContainsKey(playerID))
-        {
-            bonusVotes.Add(playerID, votedPlayerID);
-        }
-        else
-        {
-            bonusVotes[playerID] = votedPlayerID;
-        }
-
         Debug.Log($"[GameManager] Bonus votes now: {bonusVotes.Count}/{networkPlayers.Count}");
 
         // Check if all players have voted
@@ -1078,6 +1103,8 @@ public class GameManager : NetworkBehaviour
 
     public void RemovePlayer(string playerID)
     {
+        RemovePlayerFromCaches(playerID);
+
         if (!IsServer) return;
 
         for (int i = 0; i < networkPlayers.Count; i++)
@@ -1086,12 +1113,6 @@ public class GameManager : NetworkBehaviour
             {
                 networkPlayers.RemoveAt(i);
                 Debug.Log($"[GameManager] Removed player: {playerID}");
-
-                // Clean up votes and answers
-                currentRoundAnswers.Remove(playerID);
-                eliminationVotes.Remove(playerID);
-                votingVotes.Remove(playerID);
-                bonusVotes.Remove(playerID);
 
                 break;
             }
@@ -1103,15 +1124,16 @@ public class GameManager : NetworkBehaviour
     /// </summary>
     public void ClearAllPlayers()
     {
+        ClearSubmissionCachesLocal();
+
         if (!IsServer) return;
 
         networkPlayers.Clear();
 
-        // Clean up all vote/answer dictionaries
-        currentRoundAnswers.Clear();
-        eliminationVotes.Clear();
-        votingVotes.Clear();
-        bonusVotes.Clear();
+        if (IsSpawned)
+        {
+            ClearSubmissionCachesClientRpc();
+        }
 
         Debug.Log("[GameManager] Cleared all players");
     }


### PR DESCRIPTION
## Summary
- clear cached answer and vote dictionaries via client RPCs so non-host clients stay in sync after scene transitions
- update submission handlers to record data on every peer while retaining server-only progression logic
- read the bonus question index from the NetworkVariable value in the bonus question screen

## Testing
- Not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ebef8005bc832ea08df0d6f26ad505

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Correctly displays and logs the current bonus question number.
  - Prevents answers and votes from carrying over between rounds or after bonus questions.
  - Ensures removed players’ data is fully cleared from ongoing rounds.

- Stability Improvements
  - More reliable syncing between host and clients when progressing screens/rounds.
  - Automatic cache resets at round boundaries to avoid stale state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->