### PR TITLE
Use NetworkSceneManager for synchronized scene loading

### DIFF
--- a/Assets/Scripts/game_manager_script.cs
+++ b/Assets/Scripts/game_manager_script.cs
@@ -1,11 +1,12 @@
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Unity.Netcode;
 using Unity.Collections;
+using UnityEngine.SceneManagement;
+using Unity.Netcode.SceneManagement;
 
 /// <summary>
 /// Unity Netcode-based GameManager using NetworkVariables and NetworkLists
@@ -1337,7 +1338,7 @@ public class GameManager : NetworkBehaviour
     /// Server-only: Load a scene using NetworkSceneManager for synchronized transitions
     /// This method ensures all clients load the same scene at the same time
     /// </summary>
-    public void LoadScene(string sceneName)
+    public void LoadScene(string sceneName, LoadSceneMode loadMode = LoadSceneMode.Single)
     {
         // Only server can initiate scene changes in Netcode
         if (!IsServer)
@@ -1346,16 +1347,35 @@ public class GameManager : NetworkBehaviour
             return;
         }
 
-        // Use Netcode's NetworkSceneManager for proper synchronization
-        if (NetworkManager.Singleton != null && NetworkManager.Singleton.SceneManager != null)
+        var networkManager = NetworkManager.Singleton;
+        if (networkManager == null)
         {
-            NetworkManager.Singleton.SceneManager.LoadScene(sceneName, LoadSceneMode.Single);
-            Debug.Log($"[GameManager] Server loading scene via NetworkSceneManager: {sceneName}");
+            Debug.LogError("[GameManager] Cannot load scene - NetworkManager singleton is missing.");
+            return;
         }
-        else
+
+        var sceneManager = networkManager.SceneManager;
+        if (sceneManager == null)
         {
-            Debug.LogError("[GameManager] NetworkManager.SceneManager is not available!");
+            Debug.LogError("[GameManager] Cannot load scene - NetworkSceneManager is not available.");
+            return;
         }
+
+        if (!networkManager.IsListening)
+        {
+            Debug.LogWarning($"[GameManager] NetworkManager is not listening. Falling back to local SceneManager.LoadScene for {sceneName}.");
+            SceneManager.LoadScene(sceneName, loadMode);
+            return;
+        }
+
+        var status = sceneManager.LoadScene(sceneName, loadMode);
+        if (status != SceneEventProgressStatus.Started)
+        {
+            Debug.LogError($"[GameManager] Failed to start network scene load for {sceneName}. Status: {status}");
+            return;
+        }
+
+        Debug.Log($"[GameManager] Server loading scene via NetworkSceneManager: {sceneName} (Mode: {loadMode})");
     }
 
     // === PUBLIC GETTERS ===


### PR DESCRIPTION
## Summary
- switch GameManager.LoadScene to rely on NetworkSceneManager with additive support parameter
- add safeguards when NetworkManager or SceneManager are unavailable and provide local fallback when offline

## Testing
- not run (editor only change)


------
https://chatgpt.com/codex/tasks/task_e_68ebf4e40648832e8eda53715881fa0d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Scene transitions now support selecting a load mode (e.g., Single or Additive) for greater flexibility.
  * Automatically falls back to local scene loading when network syncing isn’t available, ensuring uninterrupted play.

* Bug Fixes
  * Prevents stalled or failed scene transitions when network services are unavailable or not listening.
  * Improves reliability of network-synced scene changes with better validation and progress handling.

* Chores
  * Enhanced logging for clearer diagnostics during scene load failures and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->