### PR TITLE
Allow configuring UnityTransport listen address

### DIFF
--- a/Assets/Scripts/network_manager_script.cs
+++ b/Assets/Scripts/network_manager_script.cs
@@ -17,6 +17,12 @@ public class RWMNetworkManager : NetworkBehaviour
     public bool isHost = false;
     public ushort port = 7777;
 
+    [Tooltip("IP address clients should use to connect when this device is hosting. Leave blank to use the transport's configured address.")]
+    public string hostAddress = "";
+
+    [Tooltip("Network interface address the host should bind to. Defaults to all interfaces.")]
+    public string listenAddress = "0.0.0.0";
+
     [Header("Connection Status")]
     public bool isConnected = false;
     public string playerId = "";
@@ -156,8 +162,22 @@ public class RWMNetworkManager : NetworkBehaviour
         GenerateRoomCode();
 
         // Start as Host (Server + Client)
-        // Bind to 0.0.0.0 to allow remote connections, not just loopback
-        unityTransport.SetConnectionData("0.0.0.0", port, "0.0.0.0");
+        // Bind to the specified listen address so remote connections are accepted.
+        string advertisedAddress = hostAddress;
+
+        if (string.IsNullOrWhiteSpace(advertisedAddress))
+        {
+            advertisedAddress = unityTransport.ConnectionData.Address;
+
+            if (string.IsNullOrWhiteSpace(advertisedAddress))
+            {
+                advertisedAddress = "127.0.0.1";
+            }
+        }
+
+        string bindAddress = string.IsNullOrWhiteSpace(listenAddress) ? "0.0.0.0" : listenAddress;
+
+        unityTransport.SetConnectionData(advertisedAddress, port, bindAddress);
 
         bool success = networkManager.StartHost();
 


### PR DESCRIPTION
## Summary
- add configurable host advertised and listen addresses to `RWMNetworkManager`
- bind Unity Transport to the configured listen address so LAN clients can connect while keeping a sensible fallback for the advertised address

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ebf5a70074832e864e23666454a321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Host Address and Listen Address fields with tooltips for easier setup.
  * Hosting now selects advertised and bind addresses dynamically based on provided values, with sensible fallbacks to ensure connectivity.
  * Enables flexible configuration for local or remote hosting directly from the app settings, removing the need for code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->