### PR TITLE
Synchronize question payload and update UI listeners

### DIFF
--- a/Assets/Scripts/debug_manager_script.cs
+++ b/Assets/Scripts/debug_manager_script.cs
@@ -395,15 +395,32 @@ public class DebugManager : MonoBehaviour
             "Test submission"
         };
 
-        // Set up correct and robot answers if not already set (using NetworkVariable.Value)
-        if (string.IsNullOrEmpty(GameManager.Instance.correctAnswer.Value.ToString()))
+        // Set up correct and robot answers if not already set (using replicated payload)
+        var payload = GameManager.Instance.currentQuestionPayload.Value;
+        if (!payload.hasData)
         {
-            GameManager.Instance.correctAnswer.Value = "The Correct Answer (Debug)";
+            Debug.LogWarning("[DebugManager] Cannot simulate answers - no active question payload");
         }
-
-        if (string.IsNullOrEmpty(GameManager.Instance.robotAnswer.Value.ToString()))
+        else
         {
-            GameManager.Instance.robotAnswer.Value = "Robot Answer (Debug)";
+            bool payloadChanged = false;
+
+            if (string.IsNullOrEmpty(payload.correctAnswer.ToString()))
+            {
+                payload.correctAnswer = "The Correct Answer (Debug)";
+                payloadChanged = true;
+            }
+
+            if (string.IsNullOrEmpty(payload.robotAnswer.ToString()))
+            {
+                payload.robotAnswer = "Robot Answer (Debug)";
+                payloadChanged = true;
+            }
+
+            if (payloadChanged)
+            {
+                GameManager.Instance.currentQuestionPayload.Value = payload;
+            }
         }
 
         int index = 0;

--- a/Assets/Scripts/game_manager_script.cs
+++ b/Assets/Scripts/game_manager_script.cs
@@ -46,15 +46,13 @@ public class GameManager : NetworkBehaviour
     // === ROUND DATA ===
     [Header("Current Round Data")]
     public Question currentQuestion; // Server-only reference
-    public NetworkVariable<FixedString512Bytes> currentQuestionText = new NetworkVariable<FixedString512Bytes>();
-    public NetworkVariable<FixedString128Bytes> currentQuestionType = new NetworkVariable<FixedString128Bytes>();
-    public NetworkVariable<FixedString512Bytes> currentRobotAnecdote = new NetworkVariable<FixedString512Bytes>();
-    public NetworkVariable<FixedString512Bytes> currentImageURL = new NetworkVariable<FixedString512Bytes>();
-    public NetworkVariable<FixedString128Bytes> robotAnswer = new NetworkVariable<FixedString128Bytes>();
-    public NetworkVariable<FixedString128Bytes> correctAnswer = new NetworkVariable<FixedString128Bytes>();
+    public NetworkVariable<NetworkQuestionPayload> currentQuestionPayload = new NetworkVariable<NetworkQuestionPayload>(NetworkQuestionPayload.Empty);
     public NetworkList<FixedString128Bytes> allAnswers; // For Elimination
     public NetworkList<FixedString128Bytes> remainingAnswers; // For Voting
     public NetworkVariable<FixedString128Bytes> eliminatedAnswer = new NetworkVariable<FixedString128Bytes>();
+
+    // === EVENTS ===
+    public event System.Action<Question> QuestionUpdated;
 
     // === BONUS ROUND DATA ===
     [Header("Bonus Round Data")]
@@ -192,6 +190,8 @@ public class GameManager : NetworkBehaviour
         Debug.Log($"[GameManager] NetworkSpawn - IsServer: {IsServer}, IsClient: {IsClient}");
 
         // Subscribe to NetworkVariable changes for client-side reactions
+        currentQuestionPayload.OnValueChanged += HandleQuestionPayloadChanged;
+
         if (IsClient && !IsServer)
         {
             currentGameState.OnValueChanged += OnGameStateChanged;
@@ -203,6 +203,8 @@ public class GameManager : NetworkBehaviour
     public override void OnNetworkDespawn()
     {
         base.OnNetworkDespawn();
+
+        currentQuestionPayload.OnValueChanged -= HandleQuestionPayloadChanged;
 
         if (IsClient && !IsServer)
         {
@@ -253,6 +255,16 @@ public class GameManager : NetworkBehaviour
         Debug.Log($"[GameManager] Timer active: {oldValue} → {newValue}");
     }
 
+    private void HandleQuestionPayloadChanged(NetworkQuestionPayload previous, NetworkQuestionPayload current)
+    {
+        currentQuestion = current.hasData ? current.ToQuestion() : null;
+
+        if (current.hasData)
+        {
+            QuestionUpdated?.Invoke(currentQuestion);
+        }
+    }
+
     // === GAME FLOW METHODS ===
 
     /// <summary>
@@ -266,6 +278,7 @@ public class GameManager : NetworkBehaviour
         isHalftimePlayed.Value = false;
         isBonusRoundPlayed.Value = false;
         currentGameState.Value = GameState.Lobby;
+        currentQuestionPayload.Value = NetworkQuestionPayload.Empty;
 
         // Reset all player scores
         for (int i = 0; i < networkPlayers.Count; i++)
@@ -453,7 +466,7 @@ public class GameManager : NetworkBehaviour
         {
             case QuestionType.Standard:
                 currentQuestion = GetStandardQuestion();
-                SyncQuestionData(currentQuestion);
+                SyncQuestionData(currentQuestion, questionType);
                 LoadScene("QuestionScreen");
                 currentGameState.Value = GameState.Question;
                 StartTimer(questionTimer);
@@ -462,14 +475,14 @@ public class GameManager : NetworkBehaviour
             case QuestionType.Player:
                 Debug.Log("[GameManager] LoadQuestionScreen - Loading Player Question");
                 currentQuestion = GetPlayerQuestion();
-                SyncQuestionData(currentQuestion);
+                SyncQuestionData(currentQuestion, questionType);
                 LoadScene("PlayerQuestionVideoScreen");
                 currentGameState.Value = GameState.Question;
                 break;
 
             case QuestionType.Picture:
                 currentQuestion = GetPictureQuestion();
-                SyncQuestionData(currentQuestion);
+                SyncQuestionData(currentQuestion, questionType);
                 LoadScene("PictureQuestionScreen");
                 currentGameState.Value = GameState.Question;
                 StartTimer(questionTimer);
@@ -531,16 +544,17 @@ public class GameManager : NetworkBehaviour
         bonusVotes.Remove(playerID);
     }
 
-    void SyncQuestionData(Question question)
+    void SyncQuestionData(Question question, QuestionType questionType)
     {
-        if (!IsServer || question == null) return;
+        if (!IsServer) return;
 
-        currentQuestionText.Value = question.questionText ?? "";
-        currentQuestionType.Value = question.questionType ?? "";
-        currentRobotAnecdote.Value = question.robotAnecdote ?? "";
-        currentImageURL.Value = question.imageURL ?? "";
-        correctAnswer.Value = question.correctAnswer ?? "";
-        robotAnswer.Value = question.robotAnswer ?? "";
+        if (question != null)
+        {
+            question.questionType = questionType.ToString();
+        }
+
+        currentQuestion = question;
+        currentQuestionPayload.Value = NetworkQuestionPayload.FromQuestion(question, questionType);
     }
 
     void CheckForSpecialScreens()
@@ -601,11 +615,23 @@ public class GameManager : NetworkBehaviour
 
     public bool IsPlayerQuestion()
     {
+        var payload = currentQuestionPayload.Value;
+        if (payload.hasData)
+        {
+            return payload.questionType == QuestionType.Player;
+        }
+
         return GetQuestionTypeForRound(currentRound.Value) == QuestionType.Player;
     }
 
     public bool IsPictureQuestion()
     {
+        var payload = currentQuestionPayload.Value;
+        if (payload.hasData)
+        {
+            return payload.questionType == QuestionType.Picture;
+        }
+
         return GetQuestionTypeForRound(currentRound.Value) == QuestionType.Picture;
     }
 
@@ -624,12 +650,13 @@ public class GameManager : NetworkBehaviour
         }
 
         // Add robot answer
-        allAnswers.Add(robotAnswer.Value);
+        var payload = currentQuestionPayload.Value;
+        allAnswers.Add(payload.robotAnswer);
 
         // For Player Questions, also add the "correct" answer as a 2nd decoy
         if (IsPlayerQuestion())
         {
-            allAnswers.Add(correctAnswer.Value);
+            allAnswers.Add(payload.correctAnswer);
         }
 
         // Shuffle the answers using Fisher-Yates
@@ -671,15 +698,17 @@ public class GameManager : NetworkBehaviour
         }
 
         // Add robot answer
-        if (!string.IsNullOrEmpty(robotAnswer.Value.ToString()))
+        var payload = currentQuestionPayload.Value;
+
+        if (!string.IsNullOrEmpty(payload.robotAnswer.ToString()))
         {
-            existingAnswers.Add(robotAnswer.Value.ToString());
+            existingAnswers.Add(payload.robotAnswer.ToString());
         }
 
         // Add correct answer (not for player questions)
-        if (!IsPlayerQuestion() && !string.IsNullOrEmpty(correctAnswer.Value.ToString()))
+        if (!IsPlayerQuestion() && !string.IsNullOrEmpty(payload.correctAnswer.ToString()))
         {
-            existingAnswers.Add(correctAnswer.Value.ToString());
+            existingAnswers.Add(payload.correctAnswer.ToString());
         }
 
         return existingAnswers;
@@ -754,9 +783,13 @@ public class GameManager : NetworkBehaviour
         eliminatedAnswer.Value = mostVoted;
 
         // Award points for correct elimination
-        bool isRobotEliminated = (eliminatedAnswer.Value.ToString() == robotAnswer.Value.ToString());
-        bool isCorrectEliminated = (eliminatedAnswer.Value.ToString() == correctAnswer.Value.ToString() && !IsPlayerQuestion());
-        bool isDecoyEliminated = (eliminatedAnswer.Value.ToString() == correctAnswer.Value.ToString() && IsPlayerQuestion()) || isRobotEliminated;
+        var payload = currentQuestionPayload.Value;
+        string robotAnswerText = payload.robotAnswer.ToString();
+        string correctAnswerText = payload.correctAnswer.ToString();
+
+        bool isRobotEliminated = (eliminatedAnswer.Value.ToString() == robotAnswerText);
+        bool isCorrectEliminated = (eliminatedAnswer.Value.ToString() == correctAnswerText && !IsPlayerQuestion());
+        bool isDecoyEliminated = (eliminatedAnswer.Value.ToString() == correctAnswerText && IsPlayerQuestion()) || isRobotEliminated;
 
         int eliminationPoints = GetEliminationPoints();
 
@@ -808,6 +841,10 @@ public class GameManager : NetworkBehaviour
         int robotVotePenalty = GetRobotVotePenalty();
         int voteReceivedPoints = GetVoteReceivedPoints();
 
+        var payload = currentQuestionPayload.Value;
+        string robotAnswerText = payload.robotAnswer.ToString();
+        string correctAnswerText = payload.correctAnswer.ToString();
+
         // Count votes received per answer
         Dictionary<string, int> votesReceived = new Dictionary<string, int>();
         foreach (var vote in votingVotes.Values)
@@ -829,7 +866,7 @@ public class GameManager : NetworkBehaviour
             {
                 // Player questions have no "correct" answer
                 // Penalty for voting robot or decoy
-                if (vote == robotAnswer.Value.ToString() || vote == correctAnswer.Value.ToString())
+                if (vote == robotAnswerText || vote == correctAnswerText)
                 {
                     AwardPoints(playerID, robotVotePenalty);
                 }
@@ -837,11 +874,11 @@ public class GameManager : NetworkBehaviour
             else
             {
                 // Standard/Picture questions
-                if (vote == correctAnswer.Value.ToString())
+                if (vote == correctAnswerText)
                 {
                     AwardPoints(playerID, correctVotePoints);
                 }
-                else if (vote == robotAnswer.Value.ToString())
+                else if (vote == robotAnswerText)
                 {
                     AwardPoints(playerID, robotVotePenalty);
                 }
@@ -1382,16 +1419,14 @@ public class GameManager : NetworkBehaviour
 
     public Question GetCurrentQuestion()
     {
-        // Build Question from synced NetworkVariables so clients can access
-        return new Question
+        var payload = currentQuestionPayload.Value;
+
+        if (!payload.hasData)
         {
-            questionText = currentQuestionText.Value.ToString(),
-            questionType = currentQuestionType.Value.ToString(),
-            robotAnecdote = currentRobotAnecdote.Value.ToString(),
-            imageURL = currentImageURL.Value.ToString(),
-            correctAnswer = correctAnswer.Value.ToString(),
-            robotAnswer = robotAnswer.Value.ToString()
-        };
+            return null;
+        }
+
+        return payload.ToQuestion();
     }
 
     public int GetCurrentRound()
@@ -1401,12 +1436,14 @@ public class GameManager : NetworkBehaviour
 
     public string GetCorrectAnswer()
     {
-        return correctAnswer.Value.ToString();
+        var payload = currentQuestionPayload.Value;
+        return payload.hasData ? payload.correctAnswer.ToString() : string.Empty;
     }
 
     public string GetRobotAnswer()
     {
-        return robotAnswer.Value.ToString();
+        var payload = currentQuestionPayload.Value;
+        return payload.hasData ? payload.robotAnswer.ToString() : string.Empty;
     }
 
     public List<string> GetAllAnswers()
@@ -1520,6 +1557,82 @@ public struct NetworkedPlayerData : INetworkSerializable
             deviceType = deviceType.ToString(),
             clientId = clientId
         };
+    }
+}
+
+public struct NetworkQuestionPayload : INetworkSerializable
+{
+    public FixedString512Bytes questionText;
+    public FixedString512Bytes robotAnecdote;
+    public FixedString512Bytes imageURL;
+    public FixedString128Bytes correctAnswer;
+    public FixedString128Bytes robotAnswer;
+    public GameManager.QuestionType questionType;
+    public bool hasData;
+
+    public static NetworkQuestionPayload Empty => new NetworkQuestionPayload
+    {
+        questionText = string.Empty,
+        robotAnecdote = string.Empty,
+        imageURL = string.Empty,
+        correctAnswer = string.Empty,
+        robotAnswer = string.Empty,
+        questionType = GameManager.QuestionType.Standard,
+        hasData = false
+    };
+
+    public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
+    {
+        serializer.SerializeValue(ref questionText);
+        serializer.SerializeValue(ref robotAnecdote);
+        serializer.SerializeValue(ref imageURL);
+        serializer.SerializeValue(ref correctAnswer);
+        serializer.SerializeValue(ref robotAnswer);
+        serializer.SerializeValue(ref questionType);
+        serializer.SerializeValue(ref hasData);
+    }
+
+    public Question ToQuestion()
+    {
+        if (!hasData)
+        {
+            return null;
+        }
+
+        return new Question
+        {
+            questionText = questionText.ToString(),
+            robotAnecdote = robotAnecdote.ToString(),
+            imageURL = imageURL.ToString(),
+            correctAnswer = correctAnswer.ToString(),
+            robotAnswer = robotAnswer.ToString(),
+            questionType = questionType.ToString()
+        };
+    }
+
+    public static NetworkQuestionPayload FromQuestion(Question question, GameManager.QuestionType resolvedType)
+    {
+        NetworkQuestionPayload payload = new NetworkQuestionPayload
+        {
+            questionText = string.Empty,
+            robotAnecdote = string.Empty,
+            imageURL = string.Empty,
+            correctAnswer = string.Empty,
+            robotAnswer = string.Empty,
+            questionType = resolvedType,
+            hasData = question != null
+        };
+
+        if (question != null)
+        {
+            payload.questionText = question.questionText ?? string.Empty;
+            payload.robotAnecdote = question.robotAnecdote ?? string.Empty;
+            payload.imageURL = question.imageURL ?? string.Empty;
+            payload.correctAnswer = question.correctAnswer ?? string.Empty;
+            payload.robotAnswer = question.robotAnswer ?? string.Empty;
+        }
+
+        return payload;
     }
 }
 

--- a/Assets/Scripts/picture_question_script.cs
+++ b/Assets/Scripts/picture_question_script.cs
@@ -43,10 +43,8 @@ public class PictureQuestionScreen : MonoBehaviour
 
         // Show appropriate display
         ShowAppropriateDisplay();
-        
+
         // Display picture question
-        DisplayPictureQuestion();
-        
         // Setup submit button
         if (answerSubmitButton != null)
         {
@@ -63,6 +61,23 @@ public class PictureQuestionScreen : MonoBehaviour
         if (tipText != null)
         {
             tipText.text = "DOUBLE POINTS! Describe what you see";
+        }
+    }
+
+    void OnEnable()
+    {
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.QuestionUpdated += HandleQuestionUpdated;
+            HandleQuestionUpdated(GameManager.Instance.GetCurrentQuestion());
+        }
+    }
+
+    void OnDisable()
+    {
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.QuestionUpdated -= HandleQuestionUpdated;
         }
     }
     
@@ -91,19 +106,24 @@ public class PictureQuestionScreen : MonoBehaviour
         }
     }
     
-    void DisplayPictureQuestion()
+    void HandleQuestionUpdated(Question updatedQuestion)
     {
-        Question currentQuestion = GameManager.Instance.GetCurrentQuestion();
-        
-        if (currentQuestion != null)
+        DisplayPictureQuestion(updatedQuestion);
+    }
+
+    void DisplayPictureQuestion(Question currentQuestion)
+    {
+        if (currentQuestion == null)
         {
-            // Load picture from URL or Resources
-            if (!string.IsNullOrEmpty(currentQuestion.imageURL))
-            {
-                LoadPicture(currentQuestion.imageURL);
-            }
+            Debug.LogWarning("PictureQuestionScreen - question payload not yet available");
+            return;
         }
-        
+
+        if (!string.IsNullOrEmpty(currentQuestion.imageURL))
+        {
+            LoadPicture(currentQuestion.imageURL);
+        }
+
         Debug.Log("Picture Question - Round " + GameManager.Instance.GetCurrentRound());
     }
     

--- a/Assets/Scripts/question_screen_script.cs
+++ b/Assets/Scripts/question_screen_script.cs
@@ -56,9 +56,6 @@ public class QuestionScreen : MonoBehaviour
         // Show appropriate display
         ShowAppropriateDisplay();
 
-        // Display question
-        DisplayQuestion();
-
         // Show round-specific visuals
         ShowRoundVisuals();
         
@@ -78,6 +75,23 @@ public class QuestionScreen : MonoBehaviour
         if (AudioManager.Instance != null)
         {
             AudioManager.Instance.PlayQuestionMusic();
+        }
+    }
+
+    void OnEnable()
+    {
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.QuestionUpdated += HandleQuestionUpdated;
+            HandleQuestionUpdated(GameManager.Instance.GetCurrentQuestion());
+        }
+    }
+
+    void OnDisable()
+    {
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.QuestionUpdated -= HandleQuestionUpdated;
         }
     }
 
@@ -163,62 +177,55 @@ public class QuestionScreen : MonoBehaviour
         }
     }
     
-    void DisplayQuestion()
+    void HandleQuestionUpdated(Question updatedQuestion)
     {
-        Question currentQuestion = GameManager.Instance.GetCurrentQuestion();
+        DisplayQuestion(updatedQuestion);
+    }
 
-        Debug.Log($"DisplayQuestion - currentQuestion is null: {currentQuestion == null}");
-        Debug.Log($"DisplayQuestion - questionText is null: {questionText == null}");
-
-        if (currentQuestion != null)
+    void DisplayQuestion(Question currentQuestion)
+    {
+        if (currentQuestion == null)
         {
-            Debug.Log($"DisplayQuestion - questionText content: '{currentQuestion.questionText}'");
+            Debug.LogWarning("DisplayQuestion - question payload not yet available");
+            return;
+        }
 
-            string displayText = currentQuestion.questionText;
+        Debug.Log($"DisplayQuestion - questionText is null: {questionText == null}");
+        Debug.Log($"DisplayQuestion - questionText content: '{currentQuestion.questionText}'");
 
-            // Replace [player.name] placeholder with random player name for Player Questions
-            if (GameManager.Instance.IsPlayerQuestion() && displayText.Contains("[player.name]"))
+        bool isPlayerQuestion = currentQuestion.questionType == GameManager.QuestionType.Player.ToString();
+        string displayText = currentQuestion.questionText;
+
+        // Replace [player.name] placeholder with random player name for Player Questions
+        if (isPlayerQuestion && displayText.Contains("[player.name]"))
+        {
+            List<PlayerData> allPlayers = GameManager.Instance.GetAllPlayers();
+            if (allPlayers.Count > 0)
             {
-                List<PlayerData> allPlayers = GameManager.Instance.GetAllPlayers();
-                if (allPlayers.Count > 0)
-                {
-                    // Pick a random player
-                    PlayerData randomPlayer = allPlayers[Random.Range(0, allPlayers.Count)];
-                    displayText = displayText.Replace("[player.name]", randomPlayer.playerName);
-                    Debug.Log($"Replaced [player.name] with: {randomPlayer.playerName}");
-                }
-            }
-
-            // Set desktop question text
-            if (questionText != null)
-            {
-                questionText.text = displayText;
-                Debug.Log($"DisplayQuestion - Set questionText to: '{questionText.text}'");
-            }
-
-            // Set mobile question text
-            if (mobileQuestionText != null)
-            {
-                mobileQuestionText.text = displayText;
-                Debug.Log($"DisplayQuestion - Set mobileQuestionText to: '{mobileQuestionText.text}'");
+                PlayerData randomPlayer = allPlayers[Random.Range(0, allPlayers.Count)];
+                displayText = displayText.Replace("[player.name]", randomPlayer.playerName);
+                Debug.Log($"Replaced [player.name] with: {randomPlayer.playerName}");
             }
         }
-        else
+
+        // Set desktop question text
+        if (questionText != null)
         {
-            Debug.LogError("DisplayQuestion - currentQuestion is NULL!");
+            questionText.text = displayText;
+            Debug.Log($"DisplayQuestion - Set questionText to: '{questionText.text}'");
+        }
+
+        // Set mobile question text
+        if (mobileQuestionText != null)
+        {
+            mobileQuestionText.text = displayText;
+            Debug.Log($"DisplayQuestion - Set mobileQuestionText to: '{mobileQuestionText.text}'");
         }
 
         // Set tip text based on question type
         if (tipText != null)
         {
-            if (GameManager.Instance.IsPlayerQuestion())
-            {
-                tipText.text = "Share your opinion!";
-            }
-            else
-            {
-                tipText.text = "Type your answer below";
-            }
+            tipText.text = isPlayerQuestion ? "Share your opinion!" : "Type your answer below";
         }
 
         // Animate question card sliding down (Desktop only)


### PR DESCRIPTION
## Summary
- replace the individual question NetworkVariables with a single NetworkQuestionPayload that raises QuestionUpdated events
- update elimination/voting logic and debug tooling to read from the replicated payload
- subscribe the question and picture screens to question update notifications so UIs refresh when data arrives

## Testing
- Not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ebf878743c832eb9dfbb82f6c5e6f3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Real-time question updates across screens for smoother transitions.
  - Picture questions load immediately when a valid image is available.

- Bug Fixes
  - Prevents stale or partial question/answer data from displaying.
  - Correctly replaces [player.name] only for player-specific questions.
  - Reduces intermittent display issues when switching question types.

- Refactor
  - Streamlined question data synchronization into a single, reliable payload to improve stability and consistency across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->