### PR TITLE
Limit bonus round questions

### DIFF
--- a/Assets/Scripts/question_loader_script.cs
+++ b/Assets/Scripts/question_loader_script.cs
@@ -10,6 +10,10 @@ public class QuestionLoader : MonoBehaviour
     public string pictureQuestionsPath = "picqs";
     public string bonusQuestionsPath = "bonusquestions";
 
+    [Header("Bonus Question Settings")]
+    [SerializeField]
+    private int bonusQuestionsPerRound = 4;
+
     void Awake()
     {
         gameManager = GameManager.Instance;
@@ -164,8 +168,20 @@ public class QuestionLoader : MonoBehaviour
             // Shuffle the bonus questions to ensure varied playthrough order
             ShuffleUtility.Shuffle(bonusData.miniQuestions);
 
+            int originalCount = bonusData.miniQuestions.Count;
+            int desiredCount = Mathf.Clamp(bonusQuestionsPerRound, 0, originalCount);
+            if (desiredCount < originalCount)
+            {
+                bonusData.miniQuestions = bonusData.miniQuestions.GetRange(0, desiredCount);
+            }
+
             gameManager.bonusQuestions = bonusData;
-            Debug.Log("Loaded and shuffled " + bonusData.miniQuestions.Count + " bonus questions");
+            string logMessage = "Loaded and shuffled " + originalCount + " bonus questions";
+            if (desiredCount < originalCount)
+            {
+                logMessage += ", trimmed to " + bonusData.miniQuestions.Count + " for this round";
+            }
+            Debug.Log(logMessage);
         }
         else
         {


### PR DESCRIPTION
## Summary
- add a configurable bonus question count to the question loader
- trim the shuffled bonus question list to the configured count before storing it in the game manager
- improve logging to show both the original and trimmed question totals

## Testing
- not run (Unity play mode required)

------
https://chatgpt.com/codex/tasks/task_e_68ec0327123c832e857f015239279c54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a configurable per‑round limit for bonus questions (default: 4) available in the settings UI.
  - Bonus questions are now shuffled and automatically trimmed each round to match the configured limit.
  - Enhanced feedback messages to indicate how many bonus questions were loaded and how many will be used for the round.
  - Preserves existing gameplay flow while enabling tighter control over round pacing and difficulty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->