### PR TITLE
Fix deterministic player question name selection

### DIFF
--- a/Assets/Scripts/game_manager_script.cs
+++ b/Assets/Scripts/game_manager_script.cs
@@ -544,17 +544,61 @@ public class GameManager : NetworkBehaviour
         bonusVotes.Remove(playerID);
     }
 
-    void SyncQuestionData(Question question, QuestionType questionType)
+    private Question CreateResolvedQuestion(Question question, QuestionType questionType)
+    {
+        if (question == null)
+        {
+            return null;
+        }
+
+        Question resolved = new Question
+        {
+            questionText = question.questionText,
+            correctAnswer = question.correctAnswer,
+            robotAnswer = question.robotAnswer,
+            robotAnecdote = question.robotAnecdote,
+            questionType = questionType.ToString(),
+            imageURL = question.imageURL
+        };
+
+        if (questionType == QuestionType.Player)
+        {
+            resolved.questionText = ResolvePlayerNamePlaceholder(resolved.questionText);
+        }
+
+        return resolved;
+    }
+
+    private string ResolvePlayerNamePlaceholder(string questionText)
+    {
+        if (string.IsNullOrEmpty(questionText) || !questionText.Contains("[player.name]"))
+        {
+            return questionText;
+        }
+
+        List<PlayerData> players = GetAllPlayers();
+        if (players.Count == 0)
+        {
+            Debug.LogWarning("[GameManager] Unable to resolve [player.name] placeholder - no players connected.");
+            return questionText.Replace("[player.name]", "Player");
+        }
+
+        PlayerData selectedPlayer = players[UnityEngine.Random.Range(0, players.Count)];
+        string replacement = string.IsNullOrEmpty(selectedPlayer.playerName) ? "Player" : selectedPlayer.playerName;
+
+        Debug.Log($"[GameManager] Replacing [player.name] with '{replacement}' for player question.");
+
+        return questionText.Replace("[player.name]", replacement);
+    }
+
+    private void SyncQuestionData(Question question, QuestionType questionType)
     {
         if (!IsServer) return;
 
-        if (question != null)
-        {
-            question.questionType = questionType.ToString();
-        }
+        Question resolvedQuestion = CreateResolvedQuestion(question, questionType);
 
-        currentQuestion = question;
-        currentQuestionPayload.Value = NetworkQuestionPayload.FromQuestion(question, questionType);
+        currentQuestion = resolvedQuestion;
+        currentQuestionPayload.Value = NetworkQuestionPayload.FromQuestion(resolvedQuestion, questionType);
     }
 
     void CheckForSpecialScreens()

--- a/Assets/Scripts/question_screen_script.cs
+++ b/Assets/Scripts/question_screen_script.cs
@@ -196,16 +196,9 @@ public class QuestionScreen : MonoBehaviour
         bool isPlayerQuestion = currentQuestion.questionType == GameManager.QuestionType.Player.ToString();
         string displayText = currentQuestion.questionText;
 
-        // Replace [player.name] placeholder with random player name for Player Questions
         if (isPlayerQuestion && displayText.Contains("[player.name]"))
         {
-            List<PlayerData> allPlayers = GameManager.Instance.GetAllPlayers();
-            if (allPlayers.Count > 0)
-            {
-                PlayerData randomPlayer = allPlayers[Random.Range(0, allPlayers.Count)];
-                displayText = displayText.Replace("[player.name]", randomPlayer.playerName);
-                Debug.Log($"Replaced [player.name] with: {randomPlayer.playerName}");
-            }
+            Debug.LogWarning("[QuestionScreen] Player question received without resolved [player.name] placeholder.");
         }
 
         // Set desktop question text


### PR DESCRIPTION
## Summary
- resolve player question [player.name] placeholders on the server so every client sees the same chosen player name
- emit a warning if the question screen ever receives an unresolved placeholder

## Testing
- not run (Unity project not runnable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68ec04f8187c832e946b20285fdd14e2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Player name placeholders in questions are now automatically resolved to a connected player’s name, with a fallback to “Player” when none are available.

* Bug Fixes
  * Reduced occurrences of unresolved placeholders appearing in question text.
  * Improved reliability when syncing and displaying question content.

* Refactor
  * Streamlined question resolution flow to handle placeholder substitution earlier, improving consistency across screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->