### PR TITLE
Display mini bonus question winners on bonus results screen

### DIFF
--- a/Assets/Scripts/bonus_results_script.cs
+++ b/Assets/Scripts/bonus_results_script.cs
@@ -27,6 +27,7 @@ public class BonusResultsScreen : MonoBehaviour
     [Header("Prefab Component Names")]
     [SerializeField] private string rankComponentName = "Rank";
     [SerializeField] private string playerNameComponentName = "PlayerName";
+    [SerializeField] private string questionTextComponentName = "QuestionText";
     [SerializeField] private string scoreComponentName = "Score";
     [SerializeField] private string playerIconComponentName = "PlayerIcon";
 
@@ -84,11 +85,6 @@ public class BonusResultsScreen : MonoBehaviour
     {
         Debug.Log("DisplayBonusResults called");
 
-        // Show updated scores after bonus round
-        List<PlayerData> rankedPlayers = GameManager.Instance.GetPlayersByRank();
-
-        Debug.Log($"Got {rankedPlayers.Count} ranked players");
-
         Transform container = isMobile ? mobileResultsContainer : resultsContainer;
 
         Debug.Log($"Container is null: {container == null}, isMobile: {isMobile}");
@@ -105,19 +101,46 @@ public class BonusResultsScreen : MonoBehaviour
             Destroy(child.gameObject);
         }
 
-        // Display each player's result
-        int rank = 1;
-        foreach (PlayerData player in rankedPlayers)
+        List<BonusQuestionResultInfo> bonusResults = null;
+
+        if (GameManager.Instance != null)
         {
-            Debug.Log($"Creating result row for {player.playerName} (rank {rank}, score {player.scorePercentage}%)");
-            CreateResultRow(player, rank, container);
-            rank++;
+            bonusResults = GameManager.Instance.GetBonusQuestionResults();
+        }
+
+        if (bonusResults != null && bonusResults.Count > 0)
+        {
+            Debug.Log($"Rendering {bonusResults.Count} mini bonus question results");
+
+            for (int i = 0; i < bonusResults.Count; i++)
+            {
+                CreateBonusResultRow(bonusResults[i], i + 1, container);
+            }
+        }
+        else
+        {
+            Debug.LogWarning("No bonus question results recorded; falling back to player standings display.");
+            DisplayPlayerStandingsFallback(container);
         }
 
         Debug.Log("DisplayBonusResults complete");
     }
-    
-    void CreateResultRow(PlayerData player, int rank, Transform parent)
+
+    void DisplayPlayerStandingsFallback(Transform container)
+    {
+        List<PlayerData> rankedPlayers = GameManager.Instance != null ? GameManager.Instance.GetPlayersByRank() : new List<PlayerData>();
+
+        Debug.Log($"Fallback standings count: {rankedPlayers.Count}");
+
+        int rank = 1;
+        foreach (PlayerData player in rankedPlayers)
+        {
+            CreatePlayerStandingsRow(player, rank, container);
+            rank++;
+        }
+    }
+
+    void CreatePlayerStandingsRow(PlayerData player, int rank, Transform parent)
     {
         GameObject rowObj;
 
@@ -144,7 +167,8 @@ public class BonusResultsScreen : MonoBehaviour
         // Find and activate components using configurable names
         Transform rankTransform = FindDeepChild(rowObj.transform, rankComponentName);
         Transform nameTransform = FindDeepChild(rowObj.transform, playerNameComponentName);
-        Transform scoreTransform = FindDeepChild(rowObj.transform, scoreComponentName);
+        Transform questionTransform = FindDeepChild(rowObj.transform, questionTextComponentName);
+        Transform scoreTransform = ResolveScoreTransform(rowObj.transform);
         Transform iconTransform = FindDeepChild(rowObj.transform, playerIconComponentName);
 
         // Activate and set rank
@@ -163,6 +187,12 @@ public class BonusResultsScreen : MonoBehaviour
         {
             nameText.enabled = true;
             nameText.text = player.playerName;
+        }
+
+        // Hide question text for standings rows
+        if (questionTransform != null)
+        {
+            questionTransform.gameObject.SetActive(false);
         }
 
         // Activate and set score
@@ -186,6 +216,115 @@ public class BonusResultsScreen : MonoBehaviour
                 iconImage.sprite = iconSprite;
             }
         }
+    }
+
+    void CreateBonusResultRow(BonusQuestionResultInfo result, int questionNumber, Transform parent)
+    {
+        GameObject rowObj;
+
+        GameObject prefabToUse = isMobile ? mobileResultRowPrefab : resultRowPrefab;
+
+        if (prefabToUse != null)
+        {
+            rowObj = Instantiate(prefabToUse, parent);
+            rowObj.SetActive(true);
+            Debug.Log($"Instantiated bonus result row for question {questionNumber}");
+        }
+        else
+        {
+            Debug.LogWarning("Prefab is NULL, creating bonus result row programmatically");
+            rowObj = new GameObject("BonusResultRow");
+            rowObj.transform.SetParent(parent);
+            rowObj.AddComponent<RectTransform>();
+        }
+
+        Transform rankTransform = FindDeepChild(rowObj.transform, rankComponentName);
+        Transform nameTransform = FindDeepChild(rowObj.transform, playerNameComponentName);
+        Transform questionTransform = FindDeepChild(rowObj.transform, questionTextComponentName);
+        Transform scoreTransform = ResolveScoreTransform(rowObj.transform);
+        Transform iconTransform = FindDeepChild(rowObj.transform, playerIconComponentName);
+
+        if (rankTransform != null) rankTransform.gameObject.SetActive(true);
+        TextMeshProUGUI rankText = rankTransform?.GetComponent<TextMeshProUGUI>();
+        if (rankText != null)
+        {
+            rankText.enabled = true;
+            rankText.text = questionNumber.ToString();
+        }
+
+        if (nameTransform != null) nameTransform.gameObject.SetActive(true);
+        TextMeshProUGUI nameText = nameTransform?.GetComponent<TextMeshProUGUI>();
+        if (nameText != null)
+        {
+            nameText.enabled = true;
+            nameText.text = result.hasWinner ? result.winnerNames : "No votes cast";
+        }
+
+        if (questionTransform != null) questionTransform.gameObject.SetActive(true);
+        TextMeshProUGUI questionText = questionTransform?.GetComponent<TextMeshProUGUI>();
+        if (questionText != null)
+        {
+            questionText.enabled = true;
+            questionText.text = result.questionText;
+        }
+
+        if (scoreTransform != null) scoreTransform.gameObject.SetActive(true);
+        TextMeshProUGUI scoreText = scoreTransform?.GetComponent<TextMeshProUGUI>();
+        if (scoreText != null)
+        {
+            scoreText.enabled = true;
+            int pointsAwarded = result.hasWinner ? result.pointsAwarded : 0;
+            string scoreLabel = pointsAwarded > 0 ? $"+{pointsAwarded} pts" : "+0 pts";
+            if (result.hasWinner && result.winningVoteCount > 0)
+            {
+                scoreLabel += $"\n({result.winningVoteCount} votes)";
+            }
+            scoreText.text = scoreLabel;
+        }
+
+        if (iconTransform != null)
+        {
+            Image iconImage = iconTransform.GetComponent<Image>();
+            bool shouldShowIcon = result.hasWinner && !string.IsNullOrEmpty(result.winnerIcon) && PlayerManager.Instance != null;
+
+            if (iconImage != null)
+            {
+                if (shouldShowIcon)
+                {
+                    Sprite iconSprite = PlayerManager.Instance.GetPlayerIcon(result.winnerIcon);
+                    if (iconSprite != null)
+                    {
+                        iconTransform.gameObject.SetActive(true);
+                        iconImage.enabled = true;
+                        iconImage.sprite = iconSprite;
+                    }
+                    else
+                    {
+                        iconTransform.gameObject.SetActive(false);
+                    }
+                }
+                else
+                {
+                    iconTransform.gameObject.SetActive(false);
+                }
+            }
+            else
+            {
+                iconTransform.gameObject.SetActive(false);
+            }
+        }
+    }
+
+    Transform ResolveScoreTransform(Transform parent)
+    {
+        Transform scoreTransform = FindDeepChild(parent, scoreComponentName);
+
+        if (scoreTransform == null && scoreComponentName != "ScoreDiff")
+        {
+            scoreTransform = FindDeepChild(parent, "ScoreDiff");
+        }
+
+        return scoreTransform;
     }
     
     public void OnContinueClicked()

--- a/Assets/Scripts/game_manager_script.cs
+++ b/Assets/Scripts/game_manager_script.cs
@@ -37,6 +37,7 @@ public class GameManager : NetworkBehaviour
     private readonly Dictionary<string, string> eliminationVotes = new Dictionary<string, string>();
     private readonly Dictionary<string, string> votingVotes = new Dictionary<string, string>();
     private readonly Dictionary<string, string> bonusVotes = new Dictionary<string, string>();
+    private NetworkList<NetworkBonusQuestionResult> bonusQuestionResults;
 
     private ReadOnlyDictionary<string, string> readOnlyCurrentRoundAnswers;
     private ReadOnlyDictionary<string, string> readOnlyEliminationVotes;
@@ -116,6 +117,7 @@ public class GameManager : NetworkBehaviour
         readOnlyEliminationVotes = new ReadOnlyDictionary<string, string>(eliminationVotes);
         readOnlyVotingVotes = new ReadOnlyDictionary<string, string>(votingVotes);
         readOnlyBonusVotes = new ReadOnlyDictionary<string, string>(bonusVotes);
+        bonusQuestionResults = new NetworkList<NetworkBonusQuestionResult>();
 
         // Singleton setup
         if (Instance == null)
@@ -288,6 +290,8 @@ public class GameManager : NetworkBehaviour
             networkPlayers[i] = player;
         }
 
+        ClearBonusQuestionResults();
+
         Debug.Log("[GameManager] Game state reset for new game");
     }
 
@@ -307,6 +311,8 @@ public class GameManager : NetworkBehaviour
             player.scorePercentage = 0;
             networkPlayers[i] = player;
         }
+
+        ClearBonusQuestionResults();
 
         LoadScene("IntroVideoScreen");
         currentGameState.Value = GameState.IntroVideo;
@@ -383,6 +389,7 @@ public class GameManager : NetworkBehaviour
 
             case GameState.BonusIntro:
                 Debug.Log("[GameManager] Advancing from BonusIntro to BonusQuestion");
+                ClearBonusQuestionResults();
                 LoadScene("BonusQuestionScreen");
                 currentGameState.Value = GameState.BonusQuestion;
                 currentBonusQuestion.Value = 0;
@@ -534,6 +541,16 @@ public class GameManager : NetworkBehaviour
         }
 
         ClearBonusVotesLocal();
+    }
+
+    private void ClearBonusQuestionResults()
+    {
+        if (!IsServer || bonusQuestionResults == null)
+        {
+            return;
+        }
+
+        bonusQuestionResults.Clear();
     }
 
     private void RemovePlayerFromCaches(string playerID)
@@ -930,10 +947,16 @@ public class GameManager : NetworkBehaviour
 
         foreach (var vote in bonusVotes.Values)
         {
+            if (string.IsNullOrEmpty(vote))
+            {
+                continue;
+            }
+
             if (!voteCounts.ContainsKey(vote))
             {
                 voteCounts.Add(vote, 0);
             }
+
             voteCounts[vote]++;
         }
 
@@ -952,12 +975,65 @@ public class GameManager : NetworkBehaviour
 
         Debug.Log($"[GameManager] Awarding {bonusPoints} points to players with {maxVotes} votes");
 
+        // Cache player lookup for display data
+        Dictionary<string, PlayerData> playersById = new Dictionary<string, PlayerData>();
+        List<PlayerData> allPlayers = GetAllPlayers();
+        for (int i = 0; i < allPlayers.Count; i++)
+        {
+            PlayerData player = allPlayers[i];
+            if (!string.IsNullOrEmpty(player.playerID))
+            {
+                playersById[player.playerID] = player;
+            }
+        }
+
+        List<string> winnerNames = new List<string>();
+        string primaryWinnerIcon = string.Empty;
+
         foreach (var kvp in voteCounts)
         {
-            if (kvp.Value == maxVotes)
+            if (maxVotes > 0 && kvp.Value == maxVotes)
             {
                 AwardPoints(kvp.Key, bonusPoints);
+
+                if (playersById.TryGetValue(kvp.Key, out PlayerData winnerData))
+                {
+                    winnerNames.Add(winnerData.playerName);
+
+                    if (string.IsNullOrEmpty(primaryWinnerIcon) && !string.IsNullOrEmpty(winnerData.iconName))
+                    {
+                        primaryWinnerIcon = winnerData.iconName;
+                    }
+                }
+                else
+                {
+                    Debug.LogWarning($"[GameManager] Unable to resolve player data for bonus winner {kvp.Key}");
+                }
             }
+        }
+
+        string questionText = string.Empty;
+        if (bonusQuestions != null && bonusQuestions.miniQuestions != null && currentBonusQuestion.Value < bonusQuestions.miniQuestions.Count)
+        {
+            questionText = bonusQuestions.miniQuestions[currentBonusQuestion.Value];
+        }
+
+        bool hasWinner = winnerNames.Count > 0 && maxVotes > 0;
+        string displayWinnerText = hasWinner ? string.Join(", ", winnerNames) : "No votes cast";
+
+        NetworkBonusQuestionResult resultData = new NetworkBonusQuestionResult
+        {
+            questionText = string.IsNullOrEmpty(questionText) ? "Bonus question" : questionText,
+            winnerNames = displayWinnerText,
+            winnerIcon = hasWinner ? primaryWinnerIcon : string.Empty,
+            pointsAwarded = hasWinner ? bonusPoints : 0,
+            winningVoteCount = hasWinner ? maxVotes : 0,
+            hasWinner = hasWinner
+        };
+
+        if (bonusQuestionResults != null)
+        {
+            bonusQuestionResults.Add(resultData);
         }
     }
 
@@ -1202,6 +1278,23 @@ public class GameManager : NetworkBehaviour
     {
         List<PlayerData> allPlayers = GetAllPlayers();
         return allPlayers.OrderByDescending(p => p.scorePercentage).ToList();
+    }
+
+    public List<BonusQuestionResultInfo> GetBonusQuestionResults()
+    {
+        List<BonusQuestionResultInfo> results = new List<BonusQuestionResultInfo>();
+
+        if (bonusQuestionResults == null)
+        {
+            return results;
+        }
+
+        for (int i = 0; i < bonusQuestionResults.Count; i++)
+        {
+            results.Add(bonusQuestionResults[i].ToInfo());
+        }
+
+        return results;
     }
 
     // Read-only accessors for server-maintained dictionaries so UI can query submission state without modifying data
@@ -1662,6 +1755,49 @@ public class Question
 }
 
 [System.Serializable]
+public struct NetworkBonusQuestionResult : INetworkSerializable
+{
+    public FixedString512Bytes questionText;
+    public FixedString256Bytes winnerNames;
+    public FixedString64Bytes winnerIcon;
+    public int pointsAwarded;
+    public int winningVoteCount;
+    public bool hasWinner;
+
+    public void NetworkSerialize<T>(BufferSerializer<T> serializer) where T : IReaderWriter
+    {
+        serializer.SerializeValue(ref questionText);
+        serializer.SerializeValue(ref winnerNames);
+        serializer.SerializeValue(ref winnerIcon);
+        serializer.SerializeValue(ref pointsAwarded);
+        serializer.SerializeValue(ref winningVoteCount);
+        serializer.SerializeValue(ref hasWinner);
+    }
+
+    public BonusQuestionResultInfo ToInfo()
+    {
+        return new BonusQuestionResultInfo
+        {
+            questionText = questionText.ToString(),
+            winnerNames = winnerNames.ToString(),
+            winnerIcon = winnerIcon.ToString(),
+            pointsAwarded = pointsAwarded,
+            winningVoteCount = winningVoteCount,
+            hasWinner = hasWinner
+        };
+    }
+}
+
+public class BonusQuestionResultInfo
+{
+    public string questionText;
+    public string winnerNames;
+    public string winnerIcon;
+    public int pointsAwarded;
+    public int winningVoteCount;
+    public bool hasWinner;
+}
+
 public class BonusQuestion
 {
     public List<string> miniQuestions = new List<string>();


### PR DESCRIPTION
## Summary
- add a network-synced log of each mini bonus question result, including winners and points earned
- render the recorded mini bonus question results on the bonus results screen with a fallback to player standings when no data exists

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ec04d5d5e4832ea30f42457813e2db

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Bonus Results view showing question text, winners, points awarded, and vote counts.
  * Automatically falls back to a ranked player standings view when no bonus results are available.
  * Improved row rendering for both mobile and desktop, including dynamic icons and conditional fields.
  * Ensures results are accurate per bonus question and reflect awarded points to top-voted players.
  * Provides clearer feedback with robust handling when assets are missing and cleaner exit behavior for the continue action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->