### PR TITLE
Sort round results responses by fooled count

### DIFF
--- a/Assets/Scripts/round_results_script.cs
+++ b/Assets/Scripts/round_results_script.cs
@@ -458,14 +458,45 @@ public class RoundResultsScreen : MonoBehaviour
         var votingResults = GameManager.Instance.GetVotingResults();
         List<PlayerData> allPlayers = GameManager.Instance.GetAllPlayers();
 
-        // Create an entry for each player's response
+        // Build sortable data so the panel always displays highest fooled counts first
+        List<PlayerData> playersWithAnswers = new List<PlayerData>();
+        Dictionary<string, string> answersByPlayer = new Dictionary<string, string>();
+        Dictionary<string, int> fooledCountByPlayer = new Dictionary<string, int>();
+
         foreach (PlayerData player in allPlayers)
         {
-            // Get this player's answer
-            string playerAnswer = playerAnswers.ContainsKey(player.playerID) ? playerAnswers[player.playerID] : "";
-
-            if (string.IsNullOrEmpty(playerAnswer))
+            if (!playerAnswers.TryGetValue(player.playerID, out string playerAnswer) || string.IsNullOrEmpty(playerAnswer))
+            {
                 continue;
+            }
+
+            playersWithAnswers.Add(player);
+            answersByPlayer[player.playerID] = playerAnswer;
+            fooledCountByPlayer[player.playerID] = votingResults.ContainsKey(playerAnswer) ? votingResults[playerAnswer] : 0;
+        }
+
+        playersWithAnswers.Sort((a, b) =>
+        {
+            int fooledComparison = fooledCountByPlayer[b.playerID].CompareTo(fooledCountByPlayer[a.playerID]);
+            if (fooledComparison != 0)
+            {
+                return fooledComparison;
+            }
+
+            int scoreComparison = b.scorePercentage.CompareTo(a.scorePercentage);
+            if (scoreComparison != 0)
+            {
+                return scoreComparison;
+            }
+
+            return string.Compare(a.playerName, b.playerName, System.StringComparison.OrdinalIgnoreCase);
+        });
+
+        // Create an entry for each player's response, now in sorted order
+        foreach (PlayerData player in playersWithAnswers)
+        {
+            string playerAnswer = answersByPlayer[player.playerID];
+            int fooledCount = fooledCountByPlayer[player.playerID];
 
             GameObject responseObj = Instantiate(resultsPlayerResponsePrefab, panel2ResultsContainer);
 
@@ -530,7 +561,6 @@ public class RoundResultsScreen : MonoBehaviour
             if (scoreNumberText != null)
             {
                 // Calculate score from votes received on this answer
-                int fooledCount = votingResults.ContainsKey(playerAnswer) ? votingResults[playerAnswer] : 0;
                 int pointsPerVote = GameManager.Instance.GetVoteReceivedPoints();
                 int totalScore = fooledCount * pointsPerVote;
 
@@ -547,7 +577,6 @@ public class RoundResultsScreen : MonoBehaviour
             if (fooledCountTransform != null) fooledCountTransform.gameObject.SetActive(true);
             if (fooledCountText != null)
             {
-                int fooledCount = votingResults.ContainsKey(playerAnswer) ? votingResults[playerAnswer] : 0;
                 fooledCountText.text = fooledCount.ToString();
                 fooledCountText.enabled = true;
                 Debug.Log($"Panel2: Set NumberOfFooled to '{fooledCount}' (enabled={fooledCountText.enabled}, gameObject.activeSelf={fooledCountText.gameObject.activeSelf})");


### PR DESCRIPTION
## Summary
- sort the round results panel 2 entries by the number of players fooled so the most impactful answers appear first
- reuse the precomputed fooled counts when populating score and vote text to avoid duplicate lookups

## Testing
- not run (logic change only)


------
https://chatgpt.com/codex/tasks/task_e_68ec04b3acb4832eaf221d98eef901ae

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Player responses panel now consistently sorts entries by fooled count, then score percentage, then name (case-insensitive), eliminating unpredictable ordering.
  - Stabilized display IDs to reduce flicker and duplicate/misaligned entries during rapid updates.

- Refactor
  - Precomputed per-player data to avoid repeated calculations, improving responsiveness and reducing UI update jitter when populating the panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->