### PR TITLE
Fix timer animation normalization

### DIFF
--- a/Assets/Scripts/timer_animation_controller.cs
+++ b/Assets/Scripts/timer_animation_controller.cs
@@ -27,17 +27,24 @@ public class TimerAnimationController : MonoBehaviour
     }
     
     private bool isWarning = false;
-    
+    private float initialTimerValue;
+    private float previousTimeRemaining;
+    private bool hasLoggedMissingGameManager;
+
     void Start()
     {
         LoadTimerSprites();
-        
+
         if (timerAnimator == null)
         {
             timerAnimator = GetComponent<Animator>();
         }
+
+        // Use a sensible default so visuals look correct before the first timer sync
+        initialTimerValue = (timerType == TimerType.Question) ? 60f : 30f;
+        previousTimeRemaining = initialTimerValue;
     }
-    
+
     void LoadTimerSprites()
     {
         string basePath = (timerType == TimerType.Question) ? questionTimerPath : votingTimerPath;
@@ -56,31 +63,63 @@ public class TimerAnimationController : MonoBehaviour
             timerBlob.sprite = blobSprite;
         }
     }
-    
+
     void Update()
     {
-        float timeRemaining = GameManager.Instance.GetTimeRemaining();
-        
+        GameManager gameManager = GameManager.Instance;
+
+        if (gameManager == null)
+        {
+            if (!hasLoggedMissingGameManager)
+            {
+                Debug.LogWarning("[TimerAnimationController] GameManager instance not found. Timer visuals will be skipped until it becomes available.");
+                hasLoggedMissingGameManager = true;
+            }
+            return;
+        }
+
+        hasLoggedMissingGameManager = false;
+
+        float timeRemaining = gameManager.GetTimeRemaining();
+
+        // Detect when a new timer starts so we can normalize using the actual duration.
+        if (timeRemaining > previousTimeRemaining + 0.1f)
+        {
+            initialTimerValue = timeRemaining;
+        }
+
+        previousTimeRemaining = timeRemaining;
+
         UpdateTimerVisuals(timeRemaining);
         UpdateWarningState(timeRemaining);
     }
-    
+
     void UpdateTimerVisuals(float timeRemaining)
     {
         // Rotate or scale timer based on remaining time
         if (timerBlob != null)
         {
             // Rotate the blob
-            float rotationSpeed = Mathf.Lerp(50f, 200f, 1f - (timeRemaining / 60f));
+            float normalizedTime = GetNormalizedTime(timeRemaining);
+            float rotationSpeed = Mathf.Lerp(50f, 200f, 1f - normalizedTime);
             timerBlob.transform.Rotate(0, 0, rotationSpeed * Time.deltaTime);
         }
-        
+
         // Update fill amount based on time (if using filled circle)
         if (timerCircle != null && timerCircle.type == Image.Type.Filled)
         {
-            float maxTime = (timerType == TimerType.Question) ? 60f : 30f;
-            timerCircle.fillAmount = timeRemaining / maxTime;
+            timerCircle.fillAmount = GetNormalizedTime(timeRemaining);
         }
+    }
+
+    float GetNormalizedTime(float timeRemaining)
+    {
+        if (initialTimerValue <= Mathf.Epsilon)
+        {
+            return 0f;
+        }
+
+        return Mathf.Clamp01(timeRemaining / initialTimerValue);
     }
     
     void UpdateWarningState(float timeRemaining)


### PR DESCRIPTION
## Summary
- prevent the timer animation controller from dereferencing a missing GameManager instance
- normalize timer visuals based on the active timer duration instead of a hard-coded value so 30s timers animate correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec09e461c8832e9e51a3eba7d78b22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Timer fill and rotation now scale with remaining time, providing accurate countdown visuals across modes.
  * Timers reliably handle restarts by resynchronizing duration when time increases.
  * Prevents transient glitches when the game state isn’t available at startup.

* **Refactor**
  * Standardized time normalization to ensure consistent animation speed and fill behavior across different durations, with safeguards for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->