### PR TITLE
Fix score gap rendering on Final and Halftime results screens

### DIFF
--- a/Assets/Scripts/final_results_script.cs
+++ b/Assets/Scripts/final_results_script.cs
@@ -230,10 +230,10 @@ public class FinalResultsScreen : MonoBehaviour
     {
         // Get winner (highest score)
         PlayerData winner = rankedPlayers[0];
-        
+
         // Get loser (lowest score)
         PlayerData loser = rankedPlayers[rankedPlayers.Count - 1];
-        
+
         // Display winner section
         if (winnerSection != null)
         {
@@ -241,22 +241,19 @@ public class FinalResultsScreen : MonoBehaviour
             {
                 winnerHeadline.text = "MOST HUMAN";
             }
-            
+
             if (winnerName != null)
             {
                 winnerName.text = winner.playerName;
             }
-            
+
             if (winnerScore != null)
             {
                 winnerScore.text = winner.scorePercentage + "%";
             }
-            
-            if (scoreDiffWin != null)
-            {
-                scoreDiffWin.text = "+" + winner.scorePercentage + "%";
-            }
-            
+
+            UpdateWinnerScoreDifference(rankedPlayers, winner, loser);
+
             // Display winner icon
             if (winnerIconContainer != null)
             {
@@ -277,10 +274,7 @@ public class FinalResultsScreen : MonoBehaviour
                 loserName.text = loser.playerName;
             }
 
-            if (scoreDiffLose != null)
-            {
-                scoreDiffLose.text = loser.scorePercentage + "%";
-            }
+            UpdateLoserScoreDifference(rankedPlayers, winner, loser);
 
             // Display loser icon
             if (loserIconContainer != null)
@@ -288,9 +282,76 @@ public class FinalResultsScreen : MonoBehaviour
                 DisplayPlayerIcon(loser, loserIconContainer, false);
             }
         }
-        
+
         // Display all players in ranked order
         DisplayFullLeaderboard(rankedPlayers);
+    }
+
+    void UpdateWinnerScoreDifference(List<PlayerData> rankedPlayers, PlayerData winner, PlayerData loser)
+    {
+        if (scoreDiffWin == null)
+        {
+            return;
+        }
+
+        bool sharesComponentWithWinnerScore = winnerScore != null && ReferenceEquals(scoreDiffWin, winnerScore);
+        int? scoreGap = CalculateScoreGap(rankedPlayers, winner, loser);
+
+        if (sharesComponentWithWinnerScore)
+        {
+            // The scene assigns the same Text component for the winner score and difference.
+            // Keep the plain score that was already written to avoid overwriting it with a diff label.
+            return;
+        }
+
+        if (!scoreGap.HasValue)
+        {
+            scoreDiffWin.text = winner.scorePercentage + "%";
+            return;
+        }
+
+        scoreDiffWin.text = FormatScoreDifference(scoreGap.Value, true);
+    }
+
+    void UpdateLoserScoreDifference(List<PlayerData> rankedPlayers, PlayerData winner, PlayerData loser)
+    {
+        if (scoreDiffLose == null)
+        {
+            return;
+        }
+
+        int? scoreGap = CalculateScoreGap(rankedPlayers, winner, loser);
+
+        if (!scoreGap.HasValue)
+        {
+            scoreDiffLose.text = loser.scorePercentage + "%";
+            return;
+        }
+
+        scoreDiffLose.text = FormatScoreDifference(scoreGap.Value, false);
+    }
+
+    int? CalculateScoreGap(List<PlayerData> rankedPlayers, PlayerData winner, PlayerData loser)
+    {
+        if (rankedPlayers == null || rankedPlayers.Count <= 1 || winner == null || loser == null)
+        {
+            return null;
+        }
+
+        return winner.scorePercentage - loser.scorePercentage;
+    }
+
+    string FormatScoreDifference(int rawDifference, bool forWinner)
+    {
+        if (rawDifference == 0)
+        {
+            return "0%";
+        }
+
+        int signedValue = forWinner ? rawDifference : -rawDifference;
+        int magnitude = Mathf.Abs(rawDifference);
+        string prefix = signedValue > 0 ? "+" : "-";
+        return $"{prefix}{magnitude}%";
     }
     
     void DisplayMobileFinalResults(List<PlayerData> rankedPlayers)

--- a/Assets/Scripts/halftime_results_script.cs
+++ b/Assets/Scripts/halftime_results_script.cs
@@ -228,6 +228,8 @@ public class HalftimeResultsScreen : MonoBehaviour
                 DisplayPlayerGroup(losers, loserIconContainer, false);
             }
         }
+
+        UpdateScoreDifferences(winners, losers);
     }
 
     void DisplayMobileHalftimeResults(List<PlayerData> rankedPlayers)
@@ -354,6 +356,56 @@ public class HalftimeResultsScreen : MonoBehaviour
         }
 
         return rowObj;
+    }
+
+    void UpdateScoreDifferences(List<PlayerData> winners, List<PlayerData> losers)
+    {
+        if (scoreDiffWin == null && scoreDiffLose == null)
+        {
+            return;
+        }
+
+        bool hasWinner = winners != null && winners.Count > 0;
+        bool hasLoser = losers != null && losers.Count > 0;
+
+        if (!hasWinner || !hasLoser)
+        {
+            if (scoreDiffWin != null && hasWinner)
+            {
+                scoreDiffWin.text = winners[0].scorePercentage + "%";
+            }
+
+            if (scoreDiffLose != null && hasLoser)
+            {
+                scoreDiffLose.text = losers[0].scorePercentage + "%";
+            }
+
+            return;
+        }
+
+        int rawDifference = winners[0].scorePercentage - losers[0].scorePercentage;
+
+        if (scoreDiffWin != null)
+        {
+            scoreDiffWin.text = FormatScoreDifference(rawDifference, true);
+        }
+
+        if (scoreDiffLose != null)
+        {
+            scoreDiffLose.text = FormatScoreDifference(rawDifference, false);
+        }
+    }
+
+    string FormatScoreDifference(int rawDifference, bool forWinner)
+    {
+        if (rawDifference == 0)
+        {
+            return "0%";
+        }
+
+        int signedValue = forWinner ? rawDifference : -rawDifference;
+        string prefix = signedValue > 0 ? "+" : "-";
+        return $"{prefix}{Mathf.Abs(rawDifference)}%";
     }
     
     public void OnContinueClicked()


### PR DESCRIPTION
## Summary
- prevent the final results winner score text from being overwritten when the difference label shares the same component
- calculate and display score gaps for both the final results and halftime desktop sections with consistent formatting

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ec09a85688832e8c1ee97752ca943b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents crashes and incorrect displays by handling null/empty winner/loser lists and missing UI fields.
  * Preserves existing score text when shared components are used and avoids unintended overwrites.
  * Ensures score differences show correct signs and “0%” when equal, with proper field activation.

* **Refactor**
  * Centralizes score difference calculation and formatting for consistent, signed percentage output across final and halftime views.
  * Streamlines update flow by moving inline logic into reusable helpers, improving maintainability without changing public behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->