### PR TITLE
Guard question and vote screens when GameManager is unavailable

### DIFF
--- a/Assets/Scripts/elimination_screen_script.cs
+++ b/Assets/Scripts/elimination_screen_script.cs
@@ -78,12 +78,12 @@ public class EliminationScreen : MonoBehaviour
         UpdateTimerDisplay();
 
         // Check timer warning for audio
-        if (AudioManager.Instance != null)
+        if (AudioManager.Instance != null && GameManager.Instance != null)
         {
             AudioManager.Instance.CheckTimerWarning(GameManager.Instance.GetTimeRemaining());
         }
     }
-    
+
     void ShowAppropriateDisplay()
     {
         if (desktopDisplay != null)
@@ -102,16 +102,23 @@ public class EliminationScreen : MonoBehaviour
         List<string> answers;
         Transform container;
         
+        var gameManager = GameManager.Instance;
+        if (gameManager == null)
+        {
+            Debug.LogWarning("DisplayAnswers called before GameManager was ready");
+            return;
+        }
+
         if (isMobile)
         {
             // Mobile: Filter out player's own answer
-            answers = GameManager.Instance.GetEliminationAnswersForMobile(playerID);
+            answers = gameManager.GetEliminationAnswersForMobile(playerID);
             container = elimListMobile;
         }
         else
         {
             // Desktop: Show all answers
-            answers = GameManager.Instance.GetAllAnswers();
+            answers = gameManager.GetAllAnswers();
             container = answerListContainer;
         }
         
@@ -277,7 +284,7 @@ public class EliminationScreen : MonoBehaviour
         {
             RWMNetworkManager.Instance.SubmitEliminationVote(selectedAnswer);
         }
-        else
+        else if (GameManager.Instance != null)
         {
             // Fallback for local testing without network
             GameManager.Instance.SubmitEliminationVote(playerID, selectedAnswer);
@@ -304,7 +311,7 @@ public class EliminationScreen : MonoBehaviour
     
     void UpdateTimerDisplay()
     {
-        if (timerCountdown != null)
+        if (timerCountdown != null && GameManager.Instance != null)
         {
             timerCountdown.text = GameManager.Instance.GetTimerDisplay();
         }

--- a/Assets/Scripts/question_screen_script.cs
+++ b/Assets/Scripts/question_screen_script.cs
@@ -107,7 +107,7 @@ public class QuestionScreen : MonoBehaviour
         }
 
         // Check timer warning for audio
-        if (AudioManager.Instance != null)
+        if (AudioManager.Instance != null && GameManager.Instance != null)
         {
             AudioManager.Instance.CheckTimerWarning(GameManager.Instance.GetTimeRemaining());
         }
@@ -259,6 +259,12 @@ public class QuestionScreen : MonoBehaviour
     
     void ShowRoundVisuals()
     {
+        if (GameManager.Instance == null)
+        {
+            Debug.LogWarning("ShowRoundVisuals called before GameManager was ready");
+            return;
+        }
+
         int currentRound = GameManager.Instance.GetCurrentRound();
         
         // Hide all round backgrounds
@@ -334,15 +340,18 @@ public class QuestionScreen : MonoBehaviour
     
     void UpdateTimerDisplay()
     {
-        if (timerCountdown != null)
+        if (timerCountdown != null && GameManager.Instance != null)
         {
             timerCountdown.text = GameManager.Instance.GetTimerDisplay();
         }
     }
-    
+
     void UpdatePlayerStatusIndicators()
     {
-        if (playerIconContainer == null) return;
+        if (playerIconContainer == null || GameManager.Instance == null)
+        {
+            return;
+        }
 
         List<PlayerData> players = GameManager.Instance.GetAllPlayers();
 

--- a/Assets/Scripts/voting_screen_script.cs
+++ b/Assets/Scripts/voting_screen_script.cs
@@ -78,7 +78,7 @@ public class VotingScreen : MonoBehaviour
         UpdateTimerDisplay();
 
         // Check timer warning for audio
-        if (AudioManager.Instance != null)
+        if (AudioManager.Instance != null && GameManager.Instance != null)
         {
             AudioManager.Instance.CheckTimerWarning(GameManager.Instance.GetTimeRemaining());
         }
@@ -102,16 +102,23 @@ public class VotingScreen : MonoBehaviour
         List<string> answers;
         Transform container;
         
+        var gameManager = GameManager.Instance;
+        if (gameManager == null)
+        {
+            Debug.LogWarning("DisplayAnswers called before GameManager was ready");
+            return;
+        }
+
         if (isMobile)
         {
             // Mobile: Filter out player's own answer (if still remaining)
-            answers = GameManager.Instance.GetVotingAnswersForMobile(playerID);
+            answers = gameManager.GetVotingAnswersForMobile(playerID);
             container = voteListMobile;
         }
         else
         {
             // Desktop: Show all remaining answers
-            answers = GameManager.Instance.GetRemainingAnswers();
+            answers = gameManager.GetRemainingAnswers();
             container = answerListContainer;
         }
         
@@ -277,7 +284,7 @@ public class VotingScreen : MonoBehaviour
         {
             RWMNetworkManager.Instance.SubmitVotingVote(selectedAnswer);
         }
-        else
+        else if (GameManager.Instance != null)
         {
             // Fallback for local testing without network
             GameManager.Instance.SubmitVotingVote(playerID, selectedAnswer);
@@ -304,7 +311,7 @@ public class VotingScreen : MonoBehaviour
     
     void UpdateTimerDisplay()
     {
-        if (timerCountdown != null)
+        if (timerCountdown != null && GameManager.Instance != null)
         {
             timerCountdown.text = GameManager.Instance.GetTimerDisplay();
         }


### PR DESCRIPTION
## Summary
- add null checks before reading from GameManager on the question screen
- guard elimination and voting screens from running without an initialized GameManager
- ensure timer warning audio only runs when both managers exist

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec0b63ee80832e8496908d2b622e7c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved rare crashes on question, voting, and elimination screens when the game wasn’t fully initialized.
  * Improved reliability of timer display updates and warning sounds across screens.
  * Ensured answers load consistently on mobile and desktop during voting and elimination.
  * Made offline/fallback vote submissions more robust to prevent lost inputs and unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->