### PR TITLE
Fix round results voting lookup and game state updates

### DIFF
--- a/Assets/Scripts/game_manager_script.cs
+++ b/Assets/Scripts/game_manager_script.cs
@@ -1276,6 +1276,11 @@ public class GameManager : NetworkBehaviour
         return results;
     }
 
+    public Dictionary<string, string> GetVotingVotesByPlayer()
+    {
+        return new Dictionary<string, string>(votingVotes);
+    }
+
     public Dictionary<string, int> GetEliminationResults()
     {
         Dictionary<string, int> results = new Dictionary<string, int>();

--- a/Assets/Scripts/round_results_script.cs
+++ b/Assets/Scripts/round_results_script.cs
@@ -337,7 +337,7 @@ public class RoundResultsScreen : MonoBehaviour
         }
 
         // Get voting results
-        var votingVotes = GameManager.Instance.votingVotes;
+        Dictionary<string, string> votingVotes = GameManager.Instance.GetVotingVotesByPlayer();
         List<PlayerData> allPlayers = GameManager.Instance.GetAllPlayers();
 
         int trueCount = 0, robotCount = 0, otherCount = 0;
@@ -716,7 +716,7 @@ public class RoundResultsScreen : MonoBehaviour
     void UpdateNavigationButtons()
     {
         int currentRound = GameManager.Instance.GetCurrentRound();
-        int totalRounds = (GameManager.Instance.gameMode == GameManager.GameMode.EightQuestions) ? 8 : 12;
+        int totalRounds = (GameManager.Instance.gameMode.Value == GameManager.GameMode.EightQuestions) ? 8 : 12;
         
         bool isLastRound = currentRound >= totalRounds;
         
@@ -752,7 +752,7 @@ public class RoundResultsScreen : MonoBehaviour
             UnityEngine.SceneManagement.SceneManager.LoadScene("FinalResults");
         }
 
-        GameManager.Instance.currentGameState = GameManager.GameState.FinalResults;
+        GameManager.Instance.currentGameState.Value = GameManager.GameState.FinalResults;
     }
     
     string GetLocalPlayerID()


### PR DESCRIPTION
## Summary
- expose a copy of the voting votes so the round results screen can read per-player ballots without accessing private state
- update the round results screen to use the new accessor and correctly read and write network variables when toggling UI or leaving the screen

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68ec0be4ab0c832ea535d7ba5a28bb30