### PR TITLE
Show cumulative scores on results screens

### DIFF
--- a/Assets/Scripts/final_results_script.cs
+++ b/Assets/Scripts/final_results_script.cs
@@ -241,22 +241,22 @@ public class FinalResultsScreen : MonoBehaviour
             {
                 winnerHeadline.text = "MOST HUMAN";
             }
-            
+
             if (winnerName != null)
             {
                 winnerName.text = winner.playerName;
             }
-            
+
             if (winnerScore != null)
             {
                 winnerScore.text = winner.scorePercentage + "%";
             }
-            
+
             if (scoreDiffWin != null)
             {
-                scoreDiffWin.text = "+" + winner.scorePercentage + "%";
+                scoreDiffWin.text = FormatScorePercentage(winner.scorePercentage);
             }
-            
+
             // Display winner icon
             if (winnerIconContainer != null)
             {
@@ -279,7 +279,7 @@ public class FinalResultsScreen : MonoBehaviour
 
             if (scoreDiffLose != null)
             {
-                scoreDiffLose.text = loser.scorePercentage + "%";
+                scoreDiffLose.text = FormatScorePercentage(loser.scorePercentage);
             }
 
             // Display loser icon
@@ -374,6 +374,11 @@ public class FinalResultsScreen : MonoBehaviour
     {
         // This would populate a full leaderboard display
         // Implementation depends on your UI design
+    }
+
+    string FormatScorePercentage(int score)
+    {
+        return $"{score}%";
     }
     
     public void OnCreditsClicked()

--- a/Assets/Scripts/halftime_results_script.cs
+++ b/Assets/Scripts/halftime_results_script.cs
@@ -204,6 +204,13 @@ public class HalftimeResultsScreen : MonoBehaviour
             {
                 DisplayPlayerGroup(winners, winnerIconContainer, true);
             }
+
+            // Display cumulative score for the current leader
+            if (scoreDiffWin != null && winners.Count > 0)
+            {
+                int leaderScore = winners[0].scorePercentage;
+                scoreDiffWin.text = FormatScorePercentage(leaderScore);
+            }
         }
 
         // Display loser section
@@ -219,6 +226,20 @@ public class HalftimeResultsScreen : MonoBehaviour
             if (loserIconContainer != null)
             {
                 DisplayPlayerGroup(losers, loserIconContainer, false);
+            }
+
+            // Display cumulative score for the current last place player
+            if (scoreDiffLose != null)
+            {
+                if (losers.Count > 0)
+                {
+                    int lastPlaceScore = losers[losers.Count - 1].scorePercentage;
+                    scoreDiffLose.text = FormatScorePercentage(lastPlaceScore);
+                }
+                else
+                {
+                    scoreDiffLose.text = FormatScorePercentage(0);
+                }
             }
         }
     }
@@ -347,6 +368,11 @@ public class HalftimeResultsScreen : MonoBehaviour
         }
 
         return rowObj;
+    }
+
+    string FormatScorePercentage(int score)
+    {
+        return $"{score}%";
     }
     
     public void OnContinueClicked()


### PR DESCRIPTION
## Summary
- show the halftime desktop callouts with the leader and last-place cumulative scores instead of gaps
- display the winner and loser cumulative scores on the final results desktop screen
- replace the score gap formatter with a simple percentage formatter shared by each screen

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68ec0bd762e8832eadbfea917c852082