### PR TITLE
Fix host transport binding to localhost

### DIFF
--- a/Assets/Scripts/network_manager_script.cs
+++ b/Assets/Scripts/network_manager_script.cs
@@ -152,7 +152,8 @@ public class RWMNetworkManager : NetworkBehaviour
 
         // Start as Host (Server + Client)
         var transport = networkManager.GetComponent<UnityTransport>();
-        transport.SetConnectionData("127.0.0.1", port);
+        // Bind to all interfaces so remote clients can connect while the local host still loops back
+        transport.SetConnectionData("127.0.0.1", port, "0.0.0.0");
 
         bool success = networkManager.StartHost();
 


### PR DESCRIPTION
## Summary
- allow the Unity Transport host instance to listen on all interfaces while still connecting the local client via loopback

## Testing
- not run (not supported)


------
https://chatgpt.com/codex/tasks/task_e_68ec0debe4e0832e98444c9d1b6bd562