### PR TITLE
Fix AudioManager singleton lifecycle handling

### DIFF
--- a/Assets/Scripts/audio_manager_script.cs
+++ b/Assets/Scripts/audio_manager_script.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 public class AudioManager : MonoBehaviour
 {
-    public static AudioManager Instance;
+    public static AudioManager Instance { get; private set; }
     
     [Header("Audio Sources")]
     public AudioSource musicSource;
@@ -42,21 +42,20 @@ public class AudioManager : MonoBehaviour
     
     void Awake()
     {
-        if (Instance == null)
-        {
-            Instance = this;
-            DontDestroyOnLoad(gameObject);
-            
-            // Create audio sources if they don't exist
-            CreateAudioSources();
-            
-            // Load all audio clips
-            LoadAllAudio();
-        }
-        else
+        if (Instance != null && Instance != this)
         {
             Destroy(gameObject);
+            return;
         }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+
+        // Create audio sources if they don't exist
+        CreateAudioSources();
+
+        // Load all audio clips
+        LoadAllAudio();
     }
     
     void CreateAudioSources()
@@ -464,6 +463,11 @@ public class AudioManager : MonoBehaviour
     
     void OnDestroy()
     {
+        if (Instance == this)
+        {
+            Instance = null;
+        }
+
         StopAllCoroutines();
     }
 }


### PR DESCRIPTION
## Summary
- guard against duplicate AudioManager singletons by returning early when another instance already exists
- reset the AudioManager singleton reference when the owning GameObject is destroyed

## Testing
- not run (project not configured for automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68ec0e68a8f0832e8f7a52b98ebed5cc