### PR TITLE
Fix network state assignments during loading

### DIFF
--- a/Assets/Scripts/bonus_question_script.cs
+++ b/Assets/Scripts/bonus_question_script.cs
@@ -71,7 +71,7 @@ public class BonusQuestionScreen : MonoBehaviour
 
     void InitializeBonusQuestion()
     {
-        Debug.Log("InitializeBonusQuestion called for question index: " + GameManager.Instance.currentBonusQuestion);
+        Debug.Log("InitializeBonusQuestion called for question index: " + GameManager.Instance.currentBonusQuestion.Value);
 
         // Display current bonus question
         DisplayBonusQuestion();
@@ -121,7 +121,7 @@ public class BonusQuestionScreen : MonoBehaviour
     void Update()
     {
         // Check if we moved to next bonus question
-        int currentQuestionIndex = GameManager.Instance.currentBonusQuestion;
+        int currentQuestionIndex = GameManager.Instance.currentBonusQuestion.Value;
         int totalBonusQuestions = GameManager.Instance.GetBonusQuestionCount();
         if (currentQuestionIndex != lastBonusQuestionIndex && lastBonusQuestionIndex != -1 && currentQuestionIndex < totalBonusQuestions)
         {
@@ -170,7 +170,7 @@ public class BonusQuestionScreen : MonoBehaviour
         }
 
         // Show question number (1/4, 2/4, etc.)
-        int questionNum = GameManager.Instance.currentBonusQuestion + 1;
+        int questionNum = GameManager.Instance.currentBonusQuestion.Value + 1;
         int totalQuestions = GameManager.Instance.GetBonusQuestionCount();
         Debug.Log("Bonus Question " + questionNum + "/" + totalQuestions);
     }

--- a/Assets/Scripts/credits_screen_script.cs
+++ b/Assets/Scripts/credits_screen_script.cs
@@ -112,9 +112,9 @@ public class CreditsScreen : MonoBehaviour
         Debug.Log("New Game button clicked");
 
         // Reset game and return to landing
-        GameManager.Instance.currentRound = 0;
-        GameManager.Instance.isHalftimePlayed = false;
-        GameManager.Instance.isBonusRoundPlayed = false;
+        GameManager.Instance.currentRound.Value = 0;
+        GameManager.Instance.isHalftimePlayed.Value = false;
+        GameManager.Instance.isBonusRoundPlayed.Value = false;
         
         // Clear all players
         GameManager.Instance.players.Clear();

--- a/Assets/Scripts/debug_manager_script.cs
+++ b/Assets/Scripts/debug_manager_script.cs
@@ -114,8 +114,8 @@ public class DebugManager : MonoBehaviour
         scrollPosition = GUILayout.BeginScrollView(scrollPosition);
         
         GUILayout.Label("=== GAME STATE ===");
-        GUILayout.Label("Current Round: " + GameManager.Instance.currentRound);
-        GUILayout.Label("Game Mode: " + GameManager.Instance.gameMode);
+        GUILayout.Label("Current Round: " + GameManager.Instance.currentRound.Value);
+        GUILayout.Label("Game Mode: " + GameManager.Instance.gameMode.Value);
         GUILayout.Label("Players: " + GameManager.Instance.players.Count);
         GUILayout.Label("Timer: " + GameManager.Instance.GetTimerDisplay());
         
@@ -177,7 +177,7 @@ public class DebugManager : MonoBehaviour
         
         if (GUILayout.Button("Next Round"))
         {
-            GameManager.Instance.currentRound++;
+            GameManager.Instance.currentRound.Value++;
             GameManager.Instance.AdvanceToNextScreen();
         }
         
@@ -248,12 +248,12 @@ public class DebugManager : MonoBehaviour
         
         if (GUILayout.Button("Set Timer to 5 seconds"))
         {
-            GameManager.Instance.currentTimerValue = 5f;
+            GameManager.Instance.currentTimerValue.Value = 5f;
         }
         
         if (GUILayout.Button("Skip Timer"))
         {
-            GameManager.Instance.currentTimerValue = 0f;
+            GameManager.Instance.currentTimerValue.Value = 0f;
         }
         
         GUILayout.Space(10);
@@ -263,12 +263,12 @@ public class DebugManager : MonoBehaviour
         
         if (GUILayout.Button("Switch to 8Q Mode"))
         {
-            GameManager.Instance.gameMode = GameManager.GameMode.EightQuestions;
+            GameManager.Instance.gameMode.Value = GameManager.GameMode.EightQuestions;
         }
         
         if (GUILayout.Button("Switch to 12Q Mode"))
         {
-            GameManager.Instance.gameMode = GameManager.GameMode.TwelveQuestions;
+            GameManager.Instance.gameMode.Value = GameManager.GameMode.TwelveQuestions;
         }
         
         GUILayout.EndScrollView();
@@ -328,14 +328,16 @@ public class DebugManager : MonoBehaviour
         };
 
         // Set up correct and robot answers if not already set
-        if (string.IsNullOrEmpty(GameManager.Instance.correctAnswer))
+        string correctAnswer = GameManager.Instance.correctAnswer.Value.ToString();
+        if (string.IsNullOrEmpty(correctAnswer))
         {
-            GameManager.Instance.correctAnswer = "The Correct Answer (Debug)";
+            GameManager.Instance.correctAnswer.Value = "The Correct Answer (Debug)";
         }
 
-        if (string.IsNullOrEmpty(GameManager.Instance.robotAnswer))
+        string robotAnswer = GameManager.Instance.robotAnswer.Value.ToString();
+        if (string.IsNullOrEmpty(robotAnswer))
         {
-            GameManager.Instance.robotAnswer = "Robot Answer (Debug)";
+            GameManager.Instance.robotAnswer.Value = "Robot Answer (Debug)";
         }
 
         int index = 0;
@@ -458,7 +460,7 @@ public class DebugManager : MonoBehaviour
     
     public void SkipToRound(int round)
     {
-        GameManager.Instance.currentRound = round - 1;
+        GameManager.Instance.currentRound.Value = round - 1;
         GameManager.Instance.AdvanceToNextScreen();
         Debug.Log("Skipped to round " + round);
     }
@@ -492,8 +494,8 @@ public class DebugManager : MonoBehaviour
     
     public void ToggleTimer()
     {
-        GameManager.Instance.timerActive = !GameManager.Instance.timerActive;
-        Debug.Log("Timer " + (GameManager.Instance.timerActive ? "resumed" : "paused"));
+        GameManager.Instance.timerActive.Value = !GameManager.Instance.timerActive.Value;
+        Debug.Log("Timer " + (GameManager.Instance.timerActive.Value ? "resumed" : "paused"));
     }
     
     // === COROUTINE HELPER ===
@@ -508,8 +510,8 @@ public class DebugManager : MonoBehaviour
     public void LogGameState()
     {
         Debug.Log("=== GAME STATE ===");
-        Debug.Log("Round: " + GameManager.Instance.currentRound);
-        Debug.Log("Mode: " + GameManager.Instance.gameMode);
+        Debug.Log("Round: " + GameManager.Instance.currentRound.Value);
+        Debug.Log("Mode: " + GameManager.Instance.gameMode.Value);
         Debug.Log("Players: " + GameManager.Instance.players.Count);
         Debug.Log("Timer: " + GameManager.Instance.GetTimeRemaining() + "s");
         Debug.Log("Current Scene: " + SceneManager.GetActiveScene().name);

--- a/Assets/Scripts/final_results_script.cs
+++ b/Assets/Scripts/final_results_script.cs
@@ -396,9 +396,9 @@ public class FinalResultsScreen : MonoBehaviour
         MobileHaptics.HeavyImpact();
 
         // Reset game and go back to lobby
-        GameManager.Instance.currentRound = 0;
-        GameManager.Instance.isHalftimePlayed = false;
-        GameManager.Instance.isBonusRoundPlayed = false;
+        GameManager.Instance.currentRound.Value = 0;
+        GameManager.Instance.isHalftimePlayed.Value = false;
+        GameManager.Instance.isBonusRoundPlayed.Value = false;
 
         // Reset all scores
         foreach (var player in GameManager.Instance.players.Values)

--- a/Assets/Scripts/intro_video_script.cs
+++ b/Assets/Scripts/intro_video_script.cs
@@ -113,7 +113,11 @@ public class IntroVideoScreen : MonoBehaviour
         if (DeviceDetector.Instance != null && DeviceDetector.Instance.IsMobile())
         {
             UnityEngine.SceneManagement.SceneManager.LoadScene("LobbyScreen");
-            GameManager.Instance.currentGameState = GameManager.GameState.Lobby;
+
+            if (GameManager.Instance != null)
+            {
+                GameManager.Instance.currentGameState.Value = GameManager.GameState.Lobby;
+            }
         }
         else
         {

--- a/Assets/Scripts/loading_screen_script.cs
+++ b/Assets/Scripts/loading_screen_script.cs
@@ -129,7 +129,11 @@ public class LoadingScreen : MonoBehaviour
             Debug.Log("[LoadingScreen] Advancing to IntroVideoScreen");
 
         UnityEngine.SceneManagement.SceneManager.LoadScene("IntroVideoScreen");
-        GameManager.Instance.currentGameState = GameManager.GameState.IntroVideo;
+
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.currentGameState.Value = GameManager.GameState.IntroVideo;
+        }
     }
     
     // Optional: Add actual asset loading here

--- a/Assets/Scripts/lobby_screen_script.cs
+++ b/Assets/Scripts/lobby_screen_script.cs
@@ -71,7 +71,7 @@ public class LobbyScreen : MonoBehaviour
         // Set game state to Lobby
         if (GameManager.Instance != null)
         {
-            GameManager.Instance.currentGameState = GameManager.GameState.Lobby;
+            GameManager.Instance.currentGameState.Value = GameManager.GameState.Lobby;
             if (ENABLE_DEBUG_LOGS)
                 Debug.Log("[LobbyScreen] Set currentGameState to Lobby");
         }
@@ -327,7 +327,7 @@ public class LobbyScreen : MonoBehaviour
     {
         MobileHaptics.SelectionChanged();
 
-        GameManager.Instance.gameMode = mode;
+        GameManager.Instance.gameMode.Value = mode;
         Debug.Log("Game mode selected: " + mode);
         
         // Update UI to show selected mode
@@ -366,7 +366,7 @@ public class LobbyScreen : MonoBehaviour
             return;
         }
 
-        Debug.Log("Start button clicked - currentGameState: " + GameManager.Instance.currentGameState + ", currentRound: " + GameManager.Instance.currentRound);
+        Debug.Log("Start button clicked - currentGameState: " + GameManager.Instance.currentGameState.Value + ", currentRound: " + GameManager.Instance.currentRound.Value);
 
         // Advance to Round Art (which will load Round 1)
         GameManager.Instance.AdvanceToNextScreen();
@@ -784,7 +784,7 @@ public class LobbyScreen : MonoBehaviour
                 (RWMNetworkManager.Instance != null ? RWMNetworkManager.Instance.GetRoomCode() : "");
 
             waitData.text = nonHostPlayerCount + " Players\n" +
-                           (GameManager.Instance.gameMode == GameManager.GameMode.EightQuestions ? "8" : "12") + " Questions\n" +
+                           (GameManager.Instance.gameMode.Value == GameManager.GameMode.EightQuestions ? "8" : "12") + " Questions\n" +
                            displayRoomCode;
         }
 

--- a/Assets/Scripts/network_manager_script.cs
+++ b/Assets/Scripts/network_manager_script.cs
@@ -291,7 +291,7 @@ public class RWMNetworkManager : NetworkBehaviour
         if (GameManager.Instance != null && !string.IsNullOrEmpty(gameState))
         {
             GameManager.GameState state = (GameManager.GameState)Enum.Parse(typeof(GameManager.GameState), gameState);
-            GameManager.Instance.currentGameState = state;
+            GameManager.Instance.currentGameState.Value = state;
         }
     }
 
@@ -311,8 +311,8 @@ public class RWMNetworkManager : NetworkBehaviour
 
         if (GameManager.Instance != null)
         {
-            GameManager.Instance.currentTimerValue = timerValue;
-            GameManager.Instance.timerActive = isActive;
+            GameManager.Instance.currentTimerValue.Value = timerValue;
+            GameManager.Instance.timerActive.Value = isActive;
         }
     }
 
@@ -330,7 +330,7 @@ public class RWMNetworkManager : NetworkBehaviour
 
         if (GameManager.Instance != null)
         {
-            GameManager.Instance.currentRound = round;
+            GameManager.Instance.currentRound.Value = round;
         }
     }
 

--- a/Assets/Scripts/round_art_screen_script.cs
+++ b/Assets/Scripts/round_art_screen_script.cs
@@ -54,7 +54,7 @@ public class RoundArtScreen : MonoBehaviour
     
     void ShowRoundBackground()
     {
-        Debug.Log("ShowRoundBackground - Direct access to GameManager.Instance.currentRound: " + GameManager.Instance.currentRound);
+        Debug.Log("ShowRoundBackground - Direct access to GameManager.Instance.currentRound: " + GameManager.Instance.currentRound.Value);
 
         int currentRound = GameManager.Instance.GetCurrentRound();
         bool isMobile = DeviceDetector.Instance != null && DeviceDetector.Instance.IsMobile();


### PR DESCRIPTION
## Summary
- ensure the loading screen and intro video write GameManager state through NetworkVariable.Value and guard null instances
- update lobby, network sync, and other flow scripts to use NetworkVariable.Value so state changes replicate correctly
- adjust debug utilities to read and write NetworkVariables safely without bypassing their Value accessors

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ec0dc62758832ea79cd427acc0f253