### PR TITLE
Expose bonus vote state to UI

### DIFF
--- a/Assets/Scripts/bonus_question_script.cs
+++ b/Assets/Scripts/bonus_question_script.cs
@@ -422,7 +422,13 @@ public class BonusQuestionScreen : MonoBehaviour
     {
         // Update icon appearance for players who have voted
         List<PlayerData> allPlayers = GameManager.Instance.GetAllPlayers();
-        var bonusVotes = GameManager.Instance.bonusVotes;
+        var gameManager = GameManager.Instance;
+        if (gameManager == null)
+        {
+            return;
+        }
+
+        var bonusVotes = gameManager.BonusVotes;
 
         for (int i = 0; i < allPlayers.Count && i < spawnedPlayerIcons.Count; i++)
         {

--- a/Assets/Scripts/game_manager_script.cs
+++ b/Assets/Scripts/game_manager_script.cs
@@ -34,7 +34,7 @@ public class GameManager : NetworkBehaviour
     private Dictionary<string, string> currentRoundAnswers = new Dictionary<string, string>();
     private Dictionary<string, string> eliminationVotes = new Dictionary<string, string>();
     private Dictionary<string, string> votingVotes = new Dictionary<string, string>();
-    private Dictionary<string, string> bonusVotes = new Dictionary<string, string>();
+    private readonly Dictionary<string, string> bonusVotes = new Dictionary<string, string>();
 
     // === ROUND DATA ===
     [Header("Current Round Data")]
@@ -1017,6 +1017,8 @@ public class GameManager : NetworkBehaviour
         }
         return result;
     }
+
+    public IReadOnlyDictionary<string, string> BonusVotes => bonusVotes;
 
     public List<PlayerData> GetPlayersByRank()
     {


### PR DESCRIPTION
## Summary
- expose the bonus vote tracking dictionary through a read-only property in the game manager
- update the bonus question screen to consume the new property and handle missing game manager instances safely

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ec0f10e488832e8f6945a5c8ba42e4