### PR TITLE
Guard singleton managers against duplicate instances

### DIFF
--- a/Assets/Scripts/content_filter_manager.cs
+++ b/Assets/Scripts/content_filter_manager.cs
@@ -8,7 +8,7 @@ using System.Linq;
 /// </summary>
 public class ContentFilterManager : MonoBehaviour
 {
-    public static ContentFilterManager Instance;
+    public static ContentFilterManager Instance { get; private set; }
 
     [Header("Banned Words Settings")]
     public string bannedWordsFilePath = "bannedwords"; // In Resources folder
@@ -21,15 +21,22 @@ public class ContentFilterManager : MonoBehaviour
 
     void Awake()
     {
-        if (Instance == null)
-        {
-            Instance = this;
-            DontDestroyOnLoad(gameObject);
-            LoadBannedWords();
-        }
-        else
+        if (Instance != null && Instance != this)
         {
             Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+        LoadBannedWords();
+    }
+
+    void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
         }
     }
 

--- a/Assets/Scripts/debug_manager_script.cs
+++ b/Assets/Scripts/debug_manager_script.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 public class DebugManager : MonoBehaviour
 {
-    public static DebugManager Instance;
+    public static DebugManager Instance { get; private set; }
     
     [Header("Debug Settings")]
     public bool debugModeEnabled = false;
@@ -33,14 +33,21 @@ public class DebugManager : MonoBehaviour
     
     void Awake()
     {
-        if (Instance == null)
-        {
-            Instance = this;
-            DontDestroyOnLoad(gameObject);
-        }
-        else
+        if (Instance != null && Instance != this)
         {
             Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
         }
     }
     

--- a/Assets/Scripts/device_detector_script.cs
+++ b/Assets/Scripts/device_detector_script.cs
@@ -6,7 +6,7 @@ public class DeviceDetector : MonoBehaviour
     // === DEBUG FLAG - SET TO FALSE TO REMOVE ALL DEBUG LOGS ===
     private const bool ENABLE_DEBUG_LOGS = true;
 
-    public static DeviceDetector Instance;
+    public static DeviceDetector Instance { get; private set; }
     
     [Header("Device Type")]
     public DeviceType currentDevice = DeviceType.Desktop;
@@ -31,22 +31,17 @@ public class DeviceDetector : MonoBehaviour
         if (ENABLE_DEBUG_LOGS)
             Debug.Log($"[DeviceDetector] Awake called");
 
-        if (Instance == null)
+        if (Instance != null && Instance != this)
         {
-            Instance = this;
-            DontDestroyOnLoad(gameObject);
-
-            if (ENABLE_DEBUG_LOGS)
-                Debug.Log($"[DeviceDetector] Instance set, DontDestroyOnLoad applied");
-        }
-        else
-        {
-            if (ENABLE_DEBUG_LOGS)
-                Debug.Log($"[DeviceDetector] Duplicate instance found, destroying");
-
             Destroy(gameObject);
             return;
         }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+
+        if (ENABLE_DEBUG_LOGS)
+            Debug.Log($"[DeviceDetector] Instance set, DontDestroyOnLoad applied");
 
         if (autoDetectOnStart)
         {
@@ -54,6 +49,14 @@ public class DeviceDetector : MonoBehaviour
                 Debug.Log($"[DeviceDetector] Auto-detecting device type...");
 
             DetectDevice();
+        }
+    }
+
+    void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
         }
     }
     

--- a/Assets/Scripts/game_manager_script.cs
+++ b/Assets/Scripts/game_manager_script.cs
@@ -14,7 +14,7 @@ using Unity.Collections;
 public class GameManager : NetworkBehaviour
 {
     // Singleton pattern - only one GameManager exists
-    public static GameManager Instance;
+    public static GameManager Instance { get; private set; }
 
     // === CONFIGURATION ===
     [Header("Game Configuration")]
@@ -103,25 +103,24 @@ public class GameManager : NetworkBehaviour
         remainingAnswers = new NetworkList<FixedString128Bytes>();
 
         // Singleton setup
-        if (Instance == null)
-        {
-            Instance = this;
-            DontDestroyOnLoad(gameObject);
-            Debug.Log("[GameManager] Instance created");
-
-            _networkObject = GetComponent<NetworkObject>();
-
-            TrySpawnNetworkObject();
-
-            if (NetworkManager.Singleton != null)
-            {
-                NetworkManager.Singleton.OnServerStarted += HandleServerStarted;
-            }
-        }
-        else
+        if (Instance != null && Instance != this)
         {
             Debug.Log("[GameManager] Duplicate found and destroyed");
             Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+        Debug.Log("[GameManager] Instance created");
+
+        _networkObject = GetComponent<NetworkObject>();
+
+        TrySpawnNetworkObject();
+
+        if (NetworkManager.Singleton != null)
+        {
+            NetworkManager.Singleton.OnServerStarted += HandleServerStarted;
         }
     }
 
@@ -130,6 +129,11 @@ public class GameManager : NetworkBehaviour
         if (NetworkManager.Singleton != null)
         {
             NetworkManager.Singleton.OnServerStarted -= HandleServerStarted;
+        }
+
+        if (Instance == this)
+        {
+            Instance = null;
         }
     }
 

--- a/Assets/Scripts/network_manager_script.cs
+++ b/Assets/Scripts/network_manager_script.cs
@@ -10,7 +10,7 @@ using Unity.Netcode.Transports.UTP;
 /// </summary>
 public class RWMNetworkManager : NetworkBehaviour
 {
-    public static RWMNetworkManager Instance;
+    public static RWMNetworkManager Instance { get; private set; }
 
     [Header("Network Settings")]
     public string roomCode = "";
@@ -39,15 +39,22 @@ public class RWMNetworkManager : NetworkBehaviour
 
     void Awake()
     {
-        if (Instance == null)
-        {
-            Instance = this;
-            DontDestroyOnLoad(gameObject);
-            Debug.Log("[NetworkManager] Instance created");
-        }
-        else
+        if (Instance != null && Instance != this)
         {
             Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+        Debug.Log("[NetworkManager] Instance created");
+    }
+
+    void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
         }
     }
 

--- a/Assets/Scripts/picture_loader_script.cs
+++ b/Assets/Scripts/picture_loader_script.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 public class PictureQuestionLoader : MonoBehaviour
 {
-    public static PictureQuestionLoader Instance;
+    public static PictureQuestionLoader Instance { get; private set; }
     
     [Header("Picture Settings")]
     public string picturePath = "sprites/picture questions/";
@@ -15,17 +15,24 @@ public class PictureQuestionLoader : MonoBehaviour
     
     void Awake()
     {
-        if (Instance == null)
-        {
-            Instance = this;
-            DontDestroyOnLoad(gameObject);
-        }
-        else
+        if (Instance != null && Instance != this)
         {
             Destroy(gameObject);
+            return;
         }
-        
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+
         LoadAllPictures();
+    }
+
+    void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
+        }
     }
     
     void LoadAllPictures()

--- a/Assets/Scripts/player_auth_system.cs
+++ b/Assets/Scripts/player_auth_system.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 /// </summary>
 public class PlayerAuthSystem : MonoBehaviour
 {
-    public static PlayerAuthSystem Instance;
+    public static PlayerAuthSystem Instance { get; private set; }
     
     [Header("Local Player Info")]
     public string localPlayerID = "";
@@ -20,14 +20,21 @@ public class PlayerAuthSystem : MonoBehaviour
     
     void Awake()
     {
-        if (Instance == null)
-        {
-            Instance = this;
-            DontDestroyOnLoad(gameObject);
-        }
-        else
+        if (Instance != null && Instance != this)
         {
             Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+
+    void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
         }
     }
     

--- a/Assets/Scripts/player_manager_script.cs
+++ b/Assets/Scripts/player_manager_script.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 public class PlayerManager : MonoBehaviour
 {
-    public static PlayerManager Instance;
+    public static PlayerManager Instance { get; private set; }
     
     [Header("Player Icon Settings")]
     public string playerIconPath = "sprites/icons/";
@@ -14,17 +14,24 @@ public class PlayerManager : MonoBehaviour
     
     void Awake()
     {
-        if (Instance == null)
-        {
-            Instance = this;
-            DontDestroyOnLoad(gameObject);
-        }
-        else
+        if (Instance != null && Instance != this)
         {
             Destroy(gameObject);
+            return;
         }
-        
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+
         LoadPlayerIcons();
+    }
+
+    void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
+        }
     }
     
     void LoadPlayerIcons()

--- a/Assets/Scripts/scene_transition_manager.cs
+++ b/Assets/Scripts/scene_transition_manager.cs
@@ -5,7 +5,7 @@ using System.Collections;
 
 public class SceneTransitionManager : MonoBehaviour
 {
-    public static SceneTransitionManager Instance;
+    public static SceneTransitionManager Instance { get; private set; }
     
     [Header("Fade Settings")]
     public Image fadeImage;
@@ -21,20 +21,27 @@ public class SceneTransitionManager : MonoBehaviour
     
     void Awake()
     {
-        if (Instance == null)
-        {
-            Instance = this;
-            DontDestroyOnLoad(gameObject);
-            
-            // Create fade canvas if not exists
-            if (fadeImage == null)
-            {
-                CreateFadeCanvas();
-            }
-        }
-        else
+        if (Instance != null && Instance != this)
         {
             Destroy(gameObject);
+            return;
+        }
+
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+
+        // Create fade canvas if not exists
+        if (fadeImage == null)
+        {
+            CreateFadeCanvas();
+        }
+    }
+
+    void OnDestroy()
+    {
+        if (Instance == this)
+        {
+            Instance = null;
         }
     }
     


### PR DESCRIPTION
## Summary
- convert global manager singletons to use encapsulated Instance properties with early returns when duplicates appear
- reset singleton references on destruction to avoid stale global pointers and prevent duplicate loaders from running initialization
- align all major managers with consistent singleton lifecycle safeguards

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ec0f6c3d0c832eaf22dd550962dc07