### PR TITLE
Ensure host resets game state when restarting from results

### DIFF
--- a/Assets/Scripts/credits_screen_script.cs
+++ b/Assets/Scripts/credits_screen_script.cs
@@ -111,14 +111,20 @@ public class CreditsScreen : MonoBehaviour
 
         Debug.Log("New Game button clicked");
 
-        // Reset game and return to landing
-        GameManager.Instance.currentRound = 0;
-        GameManager.Instance.isHalftimePlayed = false;
-        GameManager.Instance.isBonusRoundPlayed = false;
-        
-        // Clear all players
-        GameManager.Instance.players.Clear();
-        
+        if (GameManager.Instance == null)
+        {
+            Debug.LogWarning("[Credits] GameManager not found when attempting to start a new game.");
+            return;
+        }
+
+        if (!GameManager.Instance.IsServer)
+        {
+            Debug.LogWarning("[Credits] Only the host can start a new game from the Credits screen.");
+            return;
+        }
+
+        GameManager.Instance.ResetMatchState();
+        GameManager.Instance.ClearAllPlayers();
         GameManager.Instance.AdvanceToNextScreen();
     }
     

--- a/Assets/Scripts/final_results_script.cs
+++ b/Assets/Scripts/final_results_script.cs
@@ -400,26 +400,20 @@ public class FinalResultsScreen : MonoBehaviour
     {
         MobileHaptics.HeavyImpact();
 
-        // Reset game and go back to lobby
-        GameManager.Instance.currentRound = 0;
-        GameManager.Instance.isHalftimePlayed = false;
-        GameManager.Instance.isBonusRoundPlayed = false;
-
-        // Reset all scores
-        foreach (var player in GameManager.Instance.players.Values)
+        if (GameManager.Instance == null)
         {
-            player.scorePercentage = 0;
+            Debug.LogWarning("[FinalResults] GameManager not found when attempting to start a new game.");
+            return;
         }
 
-        // Go back to lobby
-        if (SceneTransitionManager.Instance != null)
+        if (!GameManager.Instance.IsServer)
         {
-            SceneTransitionManager.Instance.LoadScene("LobbyScreen");
+            Debug.LogWarning("[FinalResults] Only the host can start a new game from the Final Results screen.");
+            return;
         }
-        else
-        {
-            UnityEngine.SceneManagement.SceneManager.LoadScene("LobbyScreen");
-        }
+
+        GameManager.Instance.ResetMatchState();
+        GameManager.Instance.HostLoadLobby();
     }
 
     public void OnShareClicked()

--- a/Assets/Scripts/game_manager_script.cs
+++ b/Assets/Scripts/game_manager_script.cs
@@ -200,6 +200,62 @@ public class GameManager : NetworkBehaviour
         LoadQuestions();
     }
 
+    /// <summary>
+    /// Resets round counters and optional player scores. Only valid on the host.
+    /// </summary>
+    /// <param name="resetScores">When true, zeroes out the score for every registered player.</param>
+    public void ResetMatchState(bool resetScores = true)
+    {
+        if (!IsServer)
+        {
+            Debug.LogWarning("[GameManager] ResetMatchState called on a client - ignoring.");
+            return;
+        }
+
+        currentRound.Value = 0;
+        isHalftimePlayed.Value = false;
+        isBonusRoundPlayed.Value = false;
+
+        if (resetScores)
+        {
+            for (int i = 0; i < networkPlayers.Count; i++)
+            {
+                var playerData = networkPlayers[i];
+                playerData.scorePercentage = 0;
+                networkPlayers[i] = playerData;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Clears all registered players from the lobby. Only valid on the host.
+    /// </summary>
+    public void ClearAllPlayers()
+    {
+        if (!IsServer)
+        {
+            Debug.LogWarning("[GameManager] ClearAllPlayers called on a client - ignoring.");
+            return;
+        }
+
+        networkPlayers.Clear();
+    }
+
+    /// <summary>
+    /// Sends the host (and connected clients) back to the lobby scene.
+    /// </summary>
+    public void HostLoadLobby()
+    {
+        if (!IsServer)
+        {
+            Debug.LogWarning("[GameManager] HostLoadLobby called on a client - ignoring.");
+            return;
+        }
+
+        LoadScene("LobbyScreen");
+        currentGameState.Value = GameState.Lobby;
+    }
+
     void Update()
     {
         // Only server updates timer


### PR DESCRIPTION
## Summary
- add host-side helpers in `GameManager` to reset match state, clear players, and return to the lobby
- update the Final Results and Credits screens to require the host before resetting and to call the new helpers

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68ec0f1ece7c832e8800798a32fb6b7d