### PR TITLE
Fix lobby game mode handling

### DIFF
--- a/Assets/Scripts/lobby_screen_script.cs
+++ b/Assets/Scripts/lobby_screen_script.cs
@@ -327,7 +327,10 @@ public class LobbyScreen : MonoBehaviour
     {
         MobileHaptics.SelectionChanged();
 
-        GameManager.Instance.gameMode = mode;
+        if (GameManager.Instance != null)
+        {
+            GameManager.Instance.gameMode.Value = mode;
+        }
         Debug.Log("Game mode selected: " + mode);
         
         // Update UI to show selected mode
@@ -783,8 +786,12 @@ public class LobbyScreen : MonoBehaviour
             string displayRoomCode = !string.IsNullOrEmpty(roomCode) ? roomCode :
                 (RWMNetworkManager.Instance != null ? RWMNetworkManager.Instance.GetRoomCode() : "");
 
+            GameManager.GameMode activeMode = GameManager.Instance != null
+                ? GameManager.Instance.gameMode.Value
+                : GameManager.GameMode.EightQuestions;
+
             waitData.text = nonHostPlayerCount + " Players\n" +
-                           (GameManager.Instance.gameMode == GameManager.GameMode.EightQuestions ? "8" : "12") + " Questions\n" +
+                           (activeMode == GameManager.GameMode.EightQuestions ? "8" : "12") + " Questions\n" +
                            displayRoomCode;
         }
 


### PR DESCRIPTION
## Summary
- ensure the lobby sets the game mode through the NetworkVariable so host selections propagate
- compute the waiting screen text using the resolved game mode value instead of the NetworkVariable object

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ec0f36ab38832eb45d8c7297e38804