### PR TITLE
Handle missing device identifiers in PlayerManager

### DIFF
--- a/Assets/Scripts/player_manager_script.cs
+++ b/Assets/Scripts/player_manager_script.cs
@@ -165,9 +165,25 @@ public class PlayerManager : MonoBehaviour
         return System.Guid.NewGuid().ToString();
     }
     
+    private const string DeviceIdPlayerPrefsKey = "PlayerManager_DeviceID";
+
     public string GetDevicePlayerID()
     {
         // Use device unique identifier for consistent player ID across sessions
-        return "player_" + SystemInfo.deviceUniqueIdentifier;
+        string deviceId = SystemInfo.deviceUniqueIdentifier;
+
+        // Some platforms (like WebGL) return an empty or unsupported identifier.
+        if (string.IsNullOrEmpty(deviceId) || deviceId == SystemInfo.unsupportedIdentifier)
+        {
+            if (!PlayerPrefs.HasKey(DeviceIdPlayerPrefsKey))
+            {
+                PlayerPrefs.SetString(DeviceIdPlayerPrefsKey, GeneratePlayerID());
+                PlayerPrefs.Save();
+            }
+
+            deviceId = PlayerPrefs.GetString(DeviceIdPlayerPrefsKey);
+        }
+
+        return "player_" + deviceId;
     }
 }


### PR DESCRIPTION
## Summary
- add a PlayerPrefs-backed fallback when `SystemInfo.deviceUniqueIdentifier` is unavailable
- persist the generated identifier so web and privacy-restricted platforms still get stable player IDs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ec1178eea0832eb0a730a327902cd2