### PR TITLE
Ensure host-controlled resets from final screens

### DIFF
--- a/Assets/Scripts/credits_screen_script.cs
+++ b/Assets/Scripts/credits_screen_script.cs
@@ -111,15 +111,19 @@ public class CreditsScreen : MonoBehaviour
 
         Debug.Log("New Game button clicked");
 
-        // Reset game and return to landing
-        GameManager.Instance.currentRound.Value = 0;
-        GameManager.Instance.isHalftimePlayed.Value = false;
-        GameManager.Instance.isBonusRoundPlayed.Value = false;
-        
-        // Clear all players
-        GameManager.Instance.players.Clear();
-        
-        GameManager.Instance.AdvanceToNextScreen();
+        if (GameManager.Instance == null)
+        {
+            Debug.LogWarning("[CreditsScreen] GameManager not available - cannot start a new game");
+            return;
+        }
+
+        if (!GameManager.Instance.HasHostAuthority())
+        {
+            Debug.LogWarning("[CreditsScreen] Only the host can start a new game from credits");
+            return;
+        }
+
+        GameManager.Instance.HostReturnToLobby(clearPlayers: true);
     }
     
     void OnDestroy()

--- a/Assets/Scripts/final_results_script.cs
+++ b/Assets/Scripts/final_results_script.cs
@@ -385,41 +385,38 @@ public class FinalResultsScreen : MonoBehaviour
     {
         MobileHaptics.MediumImpact();
 
-        // Go to Credits scene
-        if (SceneTransitionManager.Instance != null)
+        if (GameManager.Instance == null)
         {
-            SceneTransitionManager.Instance.LoadScene("CreditsScreen");
+            Debug.LogWarning("[FinalResultsScreen] GameManager not available - cannot open credits");
+            return;
         }
-        else
+
+        if (!GameManager.Instance.HasHostAuthority())
         {
-            UnityEngine.SceneManagement.SceneManager.LoadScene("CreditsScreen");
+            Debug.LogWarning("[FinalResultsScreen] Only the host can advance to the credits screen");
+            return;
         }
+
+        GameManager.Instance.AdvanceToNextScreen();
     }
 
     public void OnNewGameClicked()
     {
         MobileHaptics.HeavyImpact();
 
-        // Reset game and go back to lobby
-        GameManager.Instance.currentRound.Value = 0;
-        GameManager.Instance.isHalftimePlayed.Value = false;
-        GameManager.Instance.isBonusRoundPlayed.Value = false;
-
-        // Reset all scores
-        foreach (var player in GameManager.Instance.players.Values)
+        if (GameManager.Instance == null)
         {
-            player.scorePercentage = 0;
+            Debug.LogWarning("[FinalResultsScreen] GameManager not available - cannot start a new game");
+            return;
         }
 
-        // Go back to lobby
-        if (SceneTransitionManager.Instance != null)
+        if (!GameManager.Instance.HasHostAuthority())
         {
-            SceneTransitionManager.Instance.LoadScene("LobbyScreen");
+            Debug.LogWarning("[FinalResultsScreen] Only the host can start a new game");
+            return;
         }
-        else
-        {
-            UnityEngine.SceneManagement.SceneManager.LoadScene("LobbyScreen");
-        }
+
+        GameManager.Instance.HostReturnToLobby();
     }
 
     public void OnShareClicked()

--- a/Assets/Scripts/game_manager_script.cs
+++ b/Assets/Scripts/game_manager_script.cs
@@ -1000,6 +1000,105 @@ public class GameManager : NetworkBehaviour
         }
     }
 
+    // === HOST HELPERS ===
+
+    public bool HasHostAuthority()
+    {
+        if (RWMNetworkManager.Instance != null)
+        {
+            return RWMNetworkManager.Instance.isHost;
+        }
+
+        return IsServer;
+    }
+
+    public void HostResetMatchState(bool resetScores = true)
+    {
+        if (!HasHostAuthority())
+        {
+            Debug.LogWarning("[GameManager] HostResetMatchState called without host authority");
+            return;
+        }
+
+        ResetMatchStateInternal(resetScores);
+    }
+
+    public void HostClearPlayers()
+    {
+        if (!HasHostAuthority())
+        {
+            Debug.LogWarning("[GameManager] HostClearPlayers called without host authority");
+            return;
+        }
+
+        ClearPlayersInternal();
+    }
+
+    public void HostReturnToLobby(bool clearPlayers = false, bool resetScores = true)
+    {
+        if (!HasHostAuthority())
+        {
+            Debug.LogWarning("[GameManager] HostReturnToLobby called without host authority");
+            return;
+        }
+
+        ResetMatchStateInternal(resetScores);
+
+        if (clearPlayers)
+        {
+            ClearPlayersInternal();
+        }
+
+        LoadScene("LobbyScreen");
+        currentGameState.Value = GameState.Lobby;
+    }
+
+    private void ResetMatchStateInternal(bool resetScores)
+    {
+        Debug.Log("[GameManager] Resetting match state");
+
+        timerActive.Value = false;
+        currentTimerValue.Value = 0f;
+
+        currentRound.Value = 0;
+        isHalftimePlayed.Value = false;
+        isBonusRoundPlayed.Value = false;
+        currentBonusQuestion.Value = 0;
+        currentGameState.Value = GameState.Lobby;
+
+        currentQuestion = null;
+        robotAnswer.Value = default;
+        correctAnswer.Value = default;
+        eliminatedAnswer.Value = default;
+
+        currentRoundAnswers.Clear();
+        eliminationVotes.Clear();
+        votingVotes.Clear();
+        bonusVotes.Clear();
+        allAnswers.Clear();
+        remainingAnswers.Clear();
+
+        standardQuestionIndex = 0;
+        playerQuestionIndex = 0;
+        pictureQuestionIndex = 0;
+
+        if (resetScores)
+        {
+            for (int i = 0; i < networkPlayers.Count; i++)
+            {
+                var player = networkPlayers[i];
+                player.scorePercentage = 0;
+                networkPlayers[i] = player;
+            }
+        }
+    }
+
+    private void ClearPlayersInternal()
+    {
+        Debug.Log("[GameManager] Clearing all players");
+        networkPlayers.Clear();
+    }
+
     public PlayerData GetPlayer(string playerID)
     {
         for (int i = 0; i < networkPlayers.Count; i++)


### PR DESCRIPTION
## Summary
- add host-only helpers on the GameManager to reset match state, clear players, and return to the lobby
- gate the Final Results screen actions behind host authority and use the new reset helper when starting over
- require the host on the Credits screen before clearing players and send the flow back to the lobby through the helper

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ec11460bf8832ea2313f66c342a99b