### PR TITLE
Fix duplicate OnDestroy logic in NetworkManager

### DIFF
--- a/Assets/Scripts/network_manager_script.cs
+++ b/Assets/Scripts/network_manager_script.cs
@@ -50,14 +50,6 @@ public class RWMNetworkManager : NetworkBehaviour
         Debug.Log("[NetworkManager] Instance created");
     }
 
-    void OnDestroy()
-    {
-        if (Instance == this)
-        {
-            Instance = null;
-        }
-    }
-
     void Start()
     {
         // Get or add Unity's NetworkManager component
@@ -549,6 +541,11 @@ public class RWMNetworkManager : NetworkBehaviour
             {
                 networkManager.Shutdown();
             }
+        }
+
+        if (Instance == this)
+        {
+            Instance = null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- consolidate RWMNetworkManager cleanup into a single OnDestroy handler
- ensure callbacks are unsubscribed before clearing the singleton instance

## Testing
- not run (editor-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ec1185276c832e8f4ce85cd55f5990