### PR TITLE
Fix elimination and voting screens waiting for answer sync

### DIFF
--- a/Assets/Scripts/elimination_screen_script.cs
+++ b/Assets/Scripts/elimination_screen_script.cs
@@ -2,6 +2,8 @@ using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 using System.Collections.Generic;
+using Unity.Collections;
+using Unity.Netcode;
 
 public class EliminationScreen : MonoBehaviour
 {
@@ -30,6 +32,24 @@ public class EliminationScreen : MonoBehaviour
     private string playerID = "";
     private string selectedAnswer = "";
     private List<GameObject> spawnedAnswerButtons = new List<GameObject>();
+    private Coroutine subscriptionCoroutine;
+    private bool isSubscribedToAnswerUpdates = false;
+
+    void OnEnable()
+    {
+        BeginSubscriptionRoutine();
+    }
+
+    void OnDisable()
+    {
+        UnsubscribeFromAnswerUpdates();
+
+        if (subscriptionCoroutine != null)
+        {
+            StopCoroutine(subscriptionCoroutine);
+            subscriptionCoroutine = null;
+        }
+    }
     
     void Start()
     {
@@ -70,6 +90,9 @@ public class EliminationScreen : MonoBehaviour
         {
             AudioManager.Instance.PlayEliminationMusic();
         }
+
+        // Ensure we refresh once data is available
+        BeginSubscriptionRoutine();
     }
 
     void Update()
@@ -96,7 +119,7 @@ public class EliminationScreen : MonoBehaviour
             mobileDisplay.SetActive(isMobile);
         }
     }
-    
+
     void DisplayAnswers()
     {
         List<string> answers;
@@ -141,7 +164,65 @@ public class EliminationScreen : MonoBehaviour
             CreateAnswerButton(answer, container);
         }
     }
-    
+
+    void BeginSubscriptionRoutine()
+    {
+        if (subscriptionCoroutine == null)
+        {
+            subscriptionCoroutine = StartCoroutine(EnsureAnswerSubscription());
+        }
+    }
+
+    System.Collections.IEnumerator EnsureAnswerSubscription()
+    {
+        while (GameManager.Instance == null)
+        {
+            yield return null;
+        }
+
+        SubscribeToAnswerUpdates();
+        DisplayAnswers();
+        subscriptionCoroutine = null;
+    }
+
+    void SubscribeToAnswerUpdates()
+    {
+        if (isSubscribedToAnswerUpdates)
+        {
+            return;
+        }
+
+        var gameManager = GameManager.Instance;
+        if (gameManager == null)
+        {
+            return;
+        }
+
+        gameManager.allAnswers.OnListChanged += HandleAllAnswersChanged;
+        isSubscribedToAnswerUpdates = true;
+    }
+
+    void HandleAllAnswersChanged(NetworkListEvent<FixedString128Bytes> changeEvent)
+    {
+        DisplayAnswers();
+    }
+
+    void UnsubscribeFromAnswerUpdates()
+    {
+        if (!isSubscribedToAnswerUpdates)
+        {
+            return;
+        }
+
+        var gameManager = GameManager.Instance;
+        if (gameManager != null)
+        {
+            gameManager.allAnswers.OnListChanged -= HandleAllAnswersChanged;
+        }
+
+        isSubscribedToAnswerUpdates = false;
+    }
+
     void CreateAnswerButton(string answerText, Transform parent)
     {
         GameObject buttonObj;
@@ -324,11 +405,13 @@ public class EliminationScreen : MonoBehaviour
     
     void OnDestroy()
     {
+        OnDisable();
+
         if (elimSubmitButton != null)
         {
             elimSubmitButton.onClick.RemoveListener(OnSubmitVote);
         }
-        
+
         // Clean up button listeners
         foreach (GameObject btn in spawnedAnswerButtons)
         {

--- a/Assets/Scripts/voting_screen_script.cs
+++ b/Assets/Scripts/voting_screen_script.cs
@@ -2,6 +2,8 @@ using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 using System.Collections.Generic;
+using Unity.Collections;
+using Unity.Netcode;
 
 public class VotingScreen : MonoBehaviour
 {
@@ -30,6 +32,13 @@ public class VotingScreen : MonoBehaviour
     private string playerID = "";
     private string selectedAnswer = "";
     private List<GameObject> spawnedAnswerButtons = new List<GameObject>();
+    private Coroutine subscriptionCoroutine;
+    private bool isSubscribedToAnswerUpdates = false;
+
+    void OnEnable()
+    {
+        BeginSubscriptionRoutine();
+    }
     
     void Start()
     {
@@ -70,6 +79,9 @@ public class VotingScreen : MonoBehaviour
         {
             AudioManager.Instance.PlayVotingMusic();
         }
+
+        // Ensure we refresh once data is available
+        BeginSubscriptionRoutine();
     }
 
     void Update()
@@ -96,7 +108,7 @@ public class VotingScreen : MonoBehaviour
             mobileDisplay.SetActive(isMobile);
         }
     }
-    
+
     void DisplayAnswers()
     {
         List<string> answers;
@@ -141,7 +153,65 @@ public class VotingScreen : MonoBehaviour
             CreateAnswerButton(answer, container);
         }
     }
-    
+
+    void BeginSubscriptionRoutine()
+    {
+        if (subscriptionCoroutine == null)
+        {
+            subscriptionCoroutine = StartCoroutine(EnsureAnswerSubscription());
+        }
+    }
+
+    System.Collections.IEnumerator EnsureAnswerSubscription()
+    {
+        while (GameManager.Instance == null)
+        {
+            yield return null;
+        }
+
+        SubscribeToAnswerUpdates();
+        DisplayAnswers();
+        subscriptionCoroutine = null;
+    }
+
+    void SubscribeToAnswerUpdates()
+    {
+        if (isSubscribedToAnswerUpdates)
+        {
+            return;
+        }
+
+        var gameManager = GameManager.Instance;
+        if (gameManager == null)
+        {
+            return;
+        }
+
+        gameManager.remainingAnswers.OnListChanged += HandleRemainingAnswersChanged;
+        isSubscribedToAnswerUpdates = true;
+    }
+
+    void HandleRemainingAnswersChanged(NetworkListEvent<FixedString128Bytes> changeEvent)
+    {
+        DisplayAnswers();
+    }
+
+    void UnsubscribeFromAnswerUpdates()
+    {
+        if (!isSubscribedToAnswerUpdates)
+        {
+            return;
+        }
+
+        var gameManager = GameManager.Instance;
+        if (gameManager != null)
+        {
+            gameManager.remainingAnswers.OnListChanged -= HandleRemainingAnswersChanged;
+        }
+
+        isSubscribedToAnswerUpdates = false;
+    }
+
     void CreateAnswerButton(string answerText, Transform parent)
     {
         GameObject buttonObj;
@@ -321,14 +391,27 @@ public class VotingScreen : MonoBehaviour
     {
         return "player_" + SystemInfo.deviceUniqueIdentifier;
     }
-    
+
+    void OnDisable()
+    {
+        UnsubscribeFromAnswerUpdates();
+
+        if (subscriptionCoroutine != null)
+        {
+            StopCoroutine(subscriptionCoroutine);
+            subscriptionCoroutine = null;
+        }
+    }
+
     void OnDestroy()
     {
+        OnDisable();
+
         if (votingSubmitButton != null)
         {
             votingSubmitButton.onClick.RemoveListener(OnSubmitVote);
         }
-        
+
         // Clean up button listeners
         foreach (GameObject btn in spawnedAnswerButtons)
         {


### PR DESCRIPTION
## Summary
- subscribe the elimination screen UI to GameManager answer list updates so clients refresh once data replicates
- do the same for the voting screen, waiting for remaining answers before populating buttons
- add lifecycle cleanup to avoid duplicate subscriptions when screens are disabled or destroyed

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68ec14dece7c832e8af2a77fcab32d50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Elimination and voting screens now auto-refresh as answers change.
  - Improved mobile experience: device-aware UI, clearer selection highlighting, and submit button enables after choosing an answer.
- Bug Fixes
  - Prevents stale or missing answers by ensuring data appears as soon as it’s available.
  - Reduces glitches by cleaning up listeners when screens close, improving stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->