### PR TITLE
Fix share message formatting for mobile results

### DIFF
--- a/Assets/Scripts/final_results_script.cs
+++ b/Assets/Scripts/final_results_script.cs
@@ -567,7 +567,18 @@ public class FinalResultsScreen : MonoBehaviour
                 ? "{0} just won Robots Wearing Moustaches with {1}% human!"
                 : "{0} scored {1}% human in Robots Wearing Moustaches!";
         }
-        string shareMessage = string.Format(messageTemplate, shareDisplayName, shareScore);
+
+        string safeShareName = shareDisplayName.Replace("{", "{{").Replace("}", "}}");
+        string shareMessage;
+        try
+        {
+            shareMessage = string.Format(messageTemplate, safeShareName, shareScore);
+        }
+        catch (FormatException ex)
+        {
+            Debug.LogWarning($"Invalid share message template '{messageTemplate}': {ex.Message}");
+            shareMessage = string.Format("{0} scored {1}% human in Robots Wearing Moustaches!", safeShareName, shareScore);
+        }
 
         yield return StartCoroutine(ShareImage(filePath, shareMessage));
 


### PR DESCRIPTION
## Summary
- escape curly braces in player display names before formatting the share message
- add a fallback message and warning when the share template string is invalid

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ec1637ba7c832e979f80636797a043

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed errors when generating share messages, especially with display names containing braces or special characters.
  * Added a safe fallback message if the share template is invalid, ensuring sharing always works.
  * Improved reliability of share text construction to prevent crashes and ensure consistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->