### PR TITLE
Fix bonus question shuffle desync by sharing session seed

### DIFF
--- a/Assets/Scripts/game_manager_script.cs
+++ b/Assets/Scripts/game_manager_script.cs
@@ -77,6 +77,9 @@ public class GameManager : NetworkBehaviour
     private int playerQuestionIndex = 0;
     private int pictureQuestionIndex = 0;
 
+    [Header("Question Randomization")]
+    public NetworkVariable<int> questionShuffleSeed = new NetworkVariable<int>(0);
+
     // === ENUMS ===
     public enum GameMode
     {

--- a/Assets/Scripts/question_loader_script.cs
+++ b/Assets/Scripts/question_loader_script.cs
@@ -1,5 +1,7 @@
 using UnityEngine;
+using System;
 using System.Collections.Generic;
+using Unity.Netcode;
 
 public class QuestionLoader : MonoBehaviour
 {
@@ -13,6 +15,9 @@ public class QuestionLoader : MonoBehaviour
     [Header("Bonus Question Settings")]
     [SerializeField]
     private int bonusQuestionsPerRound = 4;
+
+    private bool hasLoadedQuestions = false;
+    private bool subscribedToShuffleSeed = false;
 
     void Awake()
     {
@@ -29,13 +34,76 @@ public class QuestionLoader : MonoBehaviour
             return;
         }
 
-        LoadAllQuestions();
+        TryLoadQuestionsWithSeed();
     }
-    
-    void LoadAllQuestions()
+
+    void TryLoadQuestionsWithSeed()
     {
-        // Seed the random number generator with current time to ensure varied shuffles across sessions
-        ShuffleUtility.SeedRandomWithTime();
+        if (hasLoadedQuestions)
+        {
+            return;
+        }
+
+        bool networkAvailable = NetworkManager.Singleton != null;
+        bool isServer = networkAvailable && NetworkManager.Singleton.IsServer;
+        bool isClientOnly = networkAvailable && NetworkManager.Singleton.IsClient && !NetworkManager.Singleton.IsServer;
+
+        if (isClientOnly)
+        {
+            int seedFromServer = gameManager.questionShuffleSeed.Value;
+
+            if (seedFromServer == 0)
+            {
+                Debug.Log("[QuestionLoader] Waiting for server shuffle seed before loading questions.");
+                if (!subscribedToShuffleSeed)
+                {
+                    gameManager.questionShuffleSeed.OnValueChanged += OnShuffleSeedChanged;
+                    subscribedToShuffleSeed = true;
+                }
+                return;
+            }
+
+            LoadAllQuestionsWithSeed(seedFromServer);
+            return;
+        }
+
+        int seed = GenerateSeedForLocalSession(isServer);
+        LoadAllQuestionsWithSeed(seed);
+    }
+
+    int GenerateSeedForLocalSession(bool isServer)
+    {
+        int seed = Environment.TickCount;
+
+        if (isServer && gameManager != null)
+        {
+            seed = UnityEngine.Random.Range(int.MinValue, int.MaxValue);
+            if (seed == 0)
+            {
+                seed = 1;
+            }
+
+            gameManager.questionShuffleSeed.Value = seed;
+        }
+        else if (seed == 0)
+        {
+            seed = 1;
+        }
+
+        return seed;
+    }
+
+    void LoadAllQuestionsWithSeed(int seed)
+    {
+        if (hasLoadedQuestions)
+        {
+            return;
+        }
+
+        hasLoadedQuestions = true;
+
+        ShuffleUtility.SeedRandom(seed);
+        Debug.Log($"[QuestionLoader] Loading questions using shuffle seed {seed}");
 
         // Load standard questions
         LoadStandardQuestions();
@@ -50,8 +118,33 @@ public class QuestionLoader : MonoBehaviour
         LoadBonusQuestions();
 
         Debug.Log("All questions loaded and shuffled successfully");
+
+        if (subscribedToShuffleSeed)
+        {
+            gameManager.questionShuffleSeed.OnValueChanged -= OnShuffleSeedChanged;
+            subscribedToShuffleSeed = false;
+        }
     }
-    
+
+    void OnShuffleSeedChanged(int previousValue, int newValue)
+    {
+        if (hasLoadedQuestions || newValue == 0)
+        {
+            return;
+        }
+
+        LoadAllQuestionsWithSeed(newValue);
+    }
+
+    void OnDestroy()
+    {
+        if (subscribedToShuffleSeed && gameManager != null)
+        {
+            gameManager.questionShuffleSeed.OnValueChanged -= OnShuffleSeedChanged;
+            subscribedToShuffleSeed = false;
+        }
+    }
+
     void LoadStandardQuestions()
     {
         TextAsset jsonFile = Resources.Load<TextAsset>(standardQuestionsPath);


### PR DESCRIPTION
## Summary
- add a network-synced shuffle seed to the GameManager so all clients share the same question order
- update QuestionLoader to wait for that seed and load/shuffle questions deterministically

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68ec16973238832ea3652c127c6bc3ab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consistent question order across all players via a synchronized randomization seed in multiplayer sessions.
  * Seeded loading ensures all question categories (standard, player, picture, bonus) are shuffled deterministically.

* **Bug Fixes**
  * Prevents duplicate question loading and reloading loops by guarding load state.
  * More reliable initialization by waiting for a valid seed before loading on clients.
  * Cleans up event subscriptions on teardown to avoid lingering listeners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->