### PR TITLE
Fix picture question display and input reset

### DIFF
--- a/Assets/Scripts/picture_question_script.cs
+++ b/Assets/Scripts/picture_question_script.cs
@@ -119,6 +119,8 @@ public class PictureQuestionScreen : MonoBehaviour
             return;
         }
 
+        ResetAnswerInput();
+
         if (!string.IsNullOrEmpty(currentQuestion.imageURL))
         {
             LoadPicture(currentQuestion.imageURL);
@@ -126,28 +128,50 @@ public class PictureQuestionScreen : MonoBehaviour
 
         Debug.Log("Picture Question - Round " + GameManager.Instance.GetCurrentRound());
     }
-    
+
     void LoadPicture(string imageURL)
     {
-        // Load image from Resources or download from URL
-        // For now, placeholder for loading logic
-        
-        // Example: Load from Resources
-        // Sprite pictureSprite = Resources.Load<Sprite>("QuestionImages/" + imageURL);
-        
-        // Set desktop picture
+        if (PictureQuestionLoader.Instance == null)
+        {
+            Debug.LogWarning("PictureQuestionScreen - PictureQuestionLoader not ready");
+            return;
+        }
+
+        Sprite pictureSprite = PictureQuestionLoader.Instance.GetPictureByImageURL(imageURL);
+
+        if (pictureSprite == null)
+        {
+            Debug.LogWarning("PictureQuestionScreen - Could not find sprite for " + imageURL);
+            return;
+        }
+
         if (picture != null)
         {
-            // picture.sprite = pictureSprite;
+            picture.sprite = pictureSprite;
+            picture.preserveAspect = true;
         }
-        
-        // Set mobile picture
+
         if (mobilePicture != null)
         {
-            // mobilePicture.sprite = pictureSprite;
+            mobilePicture.sprite = pictureSprite;
+            mobilePicture.preserveAspect = true;
         }
-        
-        Debug.Log("Loading picture: " + imageURL);
+
+        Debug.Log("Loaded picture question sprite: " + imageURL);
+    }
+
+    void ResetAnswerInput()
+    {
+        if (answerInput != null)
+        {
+            answerInput.text = string.Empty;
+            answerInput.interactable = true;
+        }
+
+        if (answerSubmitButton != null)
+        {
+            answerSubmitButton.interactable = true;
+        }
     }
     
     void UpdateTimerDisplay()


### PR DESCRIPTION
## Summary
- load picture question sprites through the shared PictureQuestionLoader so the UI shows the correct art
- reset the mobile answer input field and submit button whenever a new picture question arrives

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ec1985650c832ea0ea3df4b3326c02

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic reset of the answer input and submit controls when a picture question is shown, ensuring a clean start for each attempt.
* **Bug Fixes**
  * More reliable picture loading from links with graceful handling when images are unavailable.
  * Consistent image display on desktop and mobile with preserved aspect ratio.
  * Prevents blocked interactions caused by stale input state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->