### PR TITLE
Reset question screen mobile input state when new question loads

### DIFF
--- a/Assets/Scripts/question_screen_script.cs
+++ b/Assets/Scripts/question_screen_script.cs
@@ -215,6 +215,34 @@ public class QuestionScreen : MonoBehaviour
             Debug.Log($"DisplayQuestion - Set mobileQuestionText to: '{mobileQuestionText.text}'");
         }
 
+        // Reset mobile input state for the new question
+        if (answerInput != null)
+        {
+            answerInput.text = string.Empty;
+            answerInput.interactable = true;
+        }
+
+        if (answerSubmitButton != null)
+        {
+            answerSubmitButton.interactable = true;
+        }
+
+        if (submissionConfirmationText != null)
+        {
+            submissionConfirmationText.gameObject.SetActive(false);
+        }
+
+        if (errorMessageText != null)
+        {
+            if (errorCoroutine != null)
+            {
+                StopCoroutine(errorCoroutine);
+                errorCoroutine = null;
+            }
+
+            errorMessageText.gameObject.SetActive(false);
+        }
+
         // Set tip text based on question type
         if (tipText != null)
         {


### PR DESCRIPTION
## Summary
- reset the mobile question input, submit button, and confirmation text whenever a new question is displayed
- clear any pending error message coroutine so validation banners disappear for the next prompt

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec197a9030832ea4e80bf989b64f7d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile question screen now resets cleanly when a new question appears: answer input is cleared, submit becomes available, and any previous error or confirmation messages are removed.

* **UX Improvements**
  * Improved mobile UI state transition between questions to avoid lingering states, ensuring a fresh start for each question and smoother interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->