### PR TITLE
Reset question screen mobile input state when new question loads

### DIFF
--- a/Assets/Scripts/question_screen_script.cs
+++ b/Assets/Scripts/question_screen_script.cs
@@ -215,6 +215,34 @@ public class QuestionScreen : MonoBehaviour
             Debug.Log($"DisplayQuestion - Set mobileQuestionText to: '{mobileQuestionText.text}'");
         }
 
+        // Reset mobile input state for the new question
+        if (answerInput != null)
+        {
+            answerInput.text = string.Empty;
+            answerInput.interactable = true;
+        }
+
+        if (answerSubmitButton != null)
+        {
+            answerSubmitButton.interactable = true;
+        }
+
+        if (submissionConfirmationText != null)
+        {
+            submissionConfirmationText.gameObject.SetActive(false);
+        }
+
+        if (errorMessageText != null)
+        {
+            if (errorCoroutine != null)
+            {
+                StopCoroutine(errorCoroutine);
+                errorCoroutine = null;
+            }
+
+            errorMessageText.gameObject.SetActive(false);
+        }
+
         // Set tip text based on question type
         if (tipText != null)
         {


### PR DESCRIPTION
## Summary
- reset the mobile question input, submit button, and confirmation text whenever a new question is displayed
- clear any pending error message coroutine so validation banners disappear for the next prompt

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ec197a9030832ea4e80bf989b64f7d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mobile question screen now resets properly when a new question appears: the answer field is cleared and re-enabled, the submit button is active, previous error messages and confirmation notices are cleared/hidden, and any lingering error displays are stopped. This prevents stale UI states from carrying over between questions and ensures a clean, ready-to-answer experience on mobile. No changes to desktop behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->