### PR TITLE
Fix gendered pronouns in player question prompts

### DIFF
--- a/Assets/Resources/playerqs.json
+++ b/Assets/Resources/playerqs.json
@@ -46,7 +46,7 @@
     "Robot Answer": "109"
   },
   {
-    "Question": "What does [player.name] have sitting in her online shopping cart for the last 8 weeks?",
+    "Question": "What does [player.name] have sitting in their online shopping cart for the last 8 weeks?",
     "Right Answer": "Beekeeper starter kit",
     "Robot Answer": "Pregnancy test bulk pack"
   },
@@ -167,7 +167,7 @@
     "Robot Answer": "Bop It Extreme"
   },
   {
-    "Question": "What’s the WiFi network name [player.name] used before his current one?",
+    "Question": "What’s the WiFi network name [player.name] used before their current one?",
     "Right Answer": "ItHurtsWhenIP",
     "Robot Answer": "GetYourOwnWiFiBtch"
   },


### PR DESCRIPTION
## Summary
- replace gender-specific pronouns in player question prompts with gender-neutral wording to avoid misgendering during gameplay

## Testing
- not run (content-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ec198d3f64832e9d673ecd070839e1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated on-screen question text to use gender-neutral pronouns.
  - Changed “her online shopping cart” to “their online shopping cart.”
  - Changed “his current one” to “their current one.”
  - Impact limited to visible copy; no changes to behavior, settings, or data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->