### PR TITLE
Fix stale player cleanup after disconnect

### DIFF
--- a/Assets/Scripts/game_manager_script.cs
+++ b/Assets/Scripts/game_manager_script.cs
@@ -1308,6 +1308,21 @@ public class GameManager : NetworkBehaviour
         return null;
     }
 
+    public bool TryGetPlayerIdByClientId(ulong clientId, out string playerID)
+    {
+        for (int i = 0; i < networkPlayers.Count; i++)
+        {
+            if (networkPlayers[i].clientId == clientId)
+            {
+                playerID = networkPlayers[i].playerID.ToString();
+                return true;
+            }
+        }
+
+        playerID = null;
+        return false;
+    }
+
     public List<PlayerData> GetAllPlayers()
     {
         List<PlayerData> result = new List<PlayerData>();

--- a/Assets/Scripts/network_manager_script.cs
+++ b/Assets/Scripts/network_manager_script.cs
@@ -147,7 +147,30 @@ public class RWMNetworkManager : NetworkBehaviour
             OnConnectionError?.Invoke();
         }
 
-        OnPlayerLeft?.Invoke(clientId.ToString());
+        string disconnectedPlayerId = clientId.ToString();
+
+        if (NetworkManager.Singleton.IsServer)
+        {
+            var gameManager = GameManager.Instance ?? FindObjectOfType<GameManager>();
+
+            if (gameManager != null && gameManager.TryGetPlayerIdByClientId(clientId, out string resolvedPlayerId))
+            {
+                disconnectedPlayerId = resolvedPlayerId;
+
+                gameManager.RemovePlayer(resolvedPlayerId);
+
+                if (IsSpawned)
+                {
+                    RemovePlayerClientRpc(resolvedPlayerId);
+                }
+            }
+            else
+            {
+                Debug.LogWarning($"[NetworkManager] Unable to match disconnected client {clientId} to a player entry.");
+            }
+        }
+
+        OnPlayerLeft?.Invoke(disconnectedPlayerId);
     }
 
     // === HOST METHODS ===
@@ -288,6 +311,11 @@ public class RWMNetworkManager : NetworkBehaviour
     [ClientRpc]
     private void RemovePlayerClientRpc(string playerIdToRemove)
     {
+        if (NetworkManager.Singleton != null && NetworkManager.Singleton.IsServer && NetworkManager.Singleton.IsClient && NetworkManager.Singleton.LocalClientId == NetworkManager.ServerClientId)
+        {
+            return;
+        }
+
         if (GameManager.Instance != null)
         {
             GameManager.Instance.RemovePlayer(playerIdToRemove);


### PR DESCRIPTION
## Summary
- add a helper on `GameManager` to resolve player IDs from connected client IDs
- clear the disconnected player on the server and broadcast the removal to clients so caches stay in sync

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68ec148a20f4832eaa7c53e3d4ca660f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Players are now correctly removed from sessions upon disconnection, reducing ghost/lingering players.
  * Prevents duplicate removal on host/server to avoid inconsistent states.
  * Ensures leave events use the correct player identity instead of raw connection IDs.

* **Improvements**
  * More reliable synchronization across clients when a player leaves.
  * Increased stability and consistency in multiplayer sessions during disconnect scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->