### PR TITLE
Reset elimination and voting selections between refreshes

### DIFF
--- a/Assets/Scripts/elimination_screen_script.cs
+++ b/Assets/Scripts/elimination_screen_script.cs
@@ -42,6 +42,7 @@ public class EliminationScreen : MonoBehaviour
 
     void OnDisable()
     {
+        ResetSelectionState();
         UnsubscribeFromAnswerUpdates();
 
         if (subscriptionCoroutine != null)
@@ -124,7 +125,9 @@ public class EliminationScreen : MonoBehaviour
     {
         List<string> answers;
         Transform container;
-        
+
+        ResetSelectionState();
+
         var gameManager = GameManager.Instance;
         if (gameManager == null)
         {
@@ -162,6 +165,16 @@ public class EliminationScreen : MonoBehaviour
         foreach (string answer in answers)
         {
             CreateAnswerButton(answer, container);
+        }
+    }
+
+    void ResetSelectionState()
+    {
+        selectedAnswer = string.Empty;
+
+        if (elimSubmitButton != null)
+        {
+            elimSubmitButton.interactable = false;
         }
     }
 

--- a/Assets/Scripts/voting_screen_script.cs
+++ b/Assets/Scripts/voting_screen_script.cs
@@ -113,7 +113,9 @@ public class VotingScreen : MonoBehaviour
     {
         List<string> answers;
         Transform container;
-        
+
+        ResetSelectionState();
+
         var gameManager = GameManager.Instance;
         if (gameManager == null)
         {
@@ -151,6 +153,16 @@ public class VotingScreen : MonoBehaviour
         foreach (string answer in answers)
         {
             CreateAnswerButton(answer, container);
+        }
+    }
+
+    void ResetSelectionState()
+    {
+        selectedAnswer = string.Empty;
+
+        if (votingSubmitButton != null)
+        {
+            votingSubmitButton.interactable = false;
         }
     }
 
@@ -394,6 +406,7 @@ public class VotingScreen : MonoBehaviour
 
     void OnDisable()
     {
+        ResetSelectionState();
         UnsubscribeFromAnswerUpdates();
 
         if (subscriptionCoroutine != null)


### PR DESCRIPTION
## Summary
- clear the elimination screen selection when answers refresh or the screen disables so stale votes cannot be submitted
- apply the same selection reset to the voting screen to ensure the mobile submit button is disabled until a new choice is made

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ec1999382c832ea4147fb796ad2d62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Eliminates stale selections when returning to the Elimination and Voting screens.
  - Submit buttons now remain disabled until a new choice is made, preventing accidental submissions.

- Improvements
  - Selection state consistently resets when answers are displayed or screens are closed, ensuring a clear starting point for each round.
  - Provides a more predictable and user-friendly flow across both screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->