### PR TITLE
Fix answer button listener removal

### DIFF
--- a/Assets/Scripts/answer_button_controller.cs
+++ b/Assets/Scripts/answer_button_controller.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 using UnityEngine.EventSystems;
+using UnityEngine.Events;
 
 public class AnswerButtonController : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
 {
@@ -21,6 +22,7 @@ public class AnswerButtonController : MonoBehaviour, IPointerEnterHandler, IPoin
     private bool isSelected = false;
     private bool isHovered = false;
     private string answerContent = "";
+    private UnityAction buttonClickAction;
     
     void Awake()
     {
@@ -64,14 +66,20 @@ public class AnswerButtonController : MonoBehaviour, IPointerEnterHandler, IPoin
         
         if (button != null)
         {
-            button.onClick.RemoveAllListeners();
-            button.onClick.AddListener(() =>
+            if (buttonClickAction != null)
+            {
+                button.onClick.RemoveListener(buttonClickAction);
+            }
+
+            buttonClickAction = () =>
             {
                 MobileHaptics.SelectionChanged();
                 onClickCallback?.Invoke(answerContent);
-            });
+            };
+
+            button.onClick.AddListener(buttonClickAction);
         }
-        
+
         UpdateVisuals();
     }
     
@@ -107,7 +115,7 @@ public class AnswerButtonController : MonoBehaviour, IPointerEnterHandler, IPoin
     void UpdateVisuals()
     {
         if (background == null) return;
-        
+
         if (button != null && !button.interactable)
         {
             // Disabled state
@@ -145,5 +153,13 @@ public class AnswerButtonController : MonoBehaviour, IPointerEnterHandler, IPoin
     {
         isHovered = false;
         UpdateVisuals();
+    }
+
+    void OnDestroy()
+    {
+        if (button != null && buttonClickAction != null)
+        {
+            button.onClick.RemoveListener(buttonClickAction);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- track the AnswerButtonController click handler instead of clearing all listeners when reinitializing
- clean up the tracked handler on destroy to avoid lingering subscriptions

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ec1ad63378832ea1eba78dc5a62db2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate button actions by properly managing click listeners across reinitializations.
  * Ensures button listeners are cleaned up on destroy to avoid unexpected triggers and leaks.

* **Refactor**
  * Streamlined button listener setup to improve UI reliability and consistency.

* **Style**
  * Minor formatting cleanups for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->