### PR TITLE
Fix missing numbering on bonus results fallback rows

### DIFF
--- a/Assets/Scripts/bonus_results_script.cs
+++ b/Assets/Scripts/bonus_results_script.cs
@@ -186,7 +186,13 @@ public class BonusResultsScreen : MonoBehaviour
         if (nameText != null)
         {
             nameText.enabled = true;
-            nameText.text = player.playerName;
+            string displayName = player.playerName;
+            if (rankText == null)
+            {
+                displayName = $"{rank}. {displayName}";
+            }
+
+            nameText.text = displayName;
         }
 
         // Hide question text for standings rows
@@ -265,7 +271,17 @@ public class BonusResultsScreen : MonoBehaviour
         if (questionText != null)
         {
             questionText.enabled = true;
-            questionText.text = result.questionText;
+
+            // Some legacy prefabs do not include a dedicated rank label. In that case we
+            // prefix the question text so players still see which prompt the row
+            // represents instead of rendering a blank number column.
+            string resolvedQuestionText = result.questionText ?? string.Empty;
+            if (rankText == null)
+            {
+                resolvedQuestionText = $"Q{questionNumber}: {resolvedQuestionText}";
+            }
+
+            questionText.text = resolvedQuestionText;
         }
 
         if (scoreTransform != null) scoreTransform.gameObject.SetActive(true);


### PR DESCRIPTION
## Summary
- ensure bonus results rows still show question numbers when prefabs are missing the expected rank label by prefixing the question text
- include the player rank in fallback standings rows even when the prefab lacks a dedicated rank field

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68ec1b317bdc832e952912f1b5cbf89b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured ranks and question numbers are clearly displayed when a dedicated rank label is missing.
  * Player names are now prefixed with their rank (e.g., “1. PlayerName”) if the rank label isn’t present.
  * Bonus questions are now prefixed with their number (e.g., “Q1: Question text”) if the rank label isn’t present.
  * Preserves existing display when the rank label is available, improving readability and consistency across standings and bonus results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->