### PR TITLE
Add host-driven elimination transition broadcast

### DIFF
--- a/Assets/Scripts/game_manager_script.cs
+++ b/Assets/Scripts/game_manager_script.cs
@@ -107,6 +107,7 @@ public class GameManager : NetworkBehaviour
     }
 
     private NetworkObject _networkObject;
+    private bool eliminationTransitionDispatched = false;
 
     void Awake()
     {
@@ -284,6 +285,7 @@ public class GameManager : NetworkBehaviour
         isBonusRoundPlayed.Value = false;
         currentGameState.Value = GameState.Lobby;
         currentQuestionPayload.Value = NetworkQuestionPayload.Empty;
+        eliminationTransitionDispatched = false;
 
         // Reset all player scores
         for (int i = 0; i < networkPlayers.Count; i++)
@@ -361,6 +363,11 @@ public class GameManager : NetworkBehaviour
                 break;
 
             case GameState.Question:
+                if (!TryStartEliminationTransition())
+                {
+                    return;
+                }
+
                 LoadScene("EliminationScreen");
                 currentGameState.Value = GameState.Elimination;
                 PrepareEliminationPhase();
@@ -442,6 +449,24 @@ public class GameManager : NetworkBehaviour
         }
     }
 
+    private bool TryStartEliminationTransition()
+    {
+        if (eliminationTransitionDispatched)
+        {
+            Debug.LogWarning("[GameManager] Ignoring duplicate elimination transition request.");
+            return false;
+        }
+
+        eliminationTransitionDispatched = true;
+
+        if (RWMNetworkManager.Instance != null)
+        {
+            RWMNetworkManager.Instance.BroadcastTransitionToElimination();
+        }
+
+        return true;
+    }
+
     void StartNextRound()
     {
         if (!IsServer) return;
@@ -467,6 +492,8 @@ public class GameManager : NetworkBehaviour
     void LoadQuestionScreen()
     {
         if (!IsServer) return;
+
+        eliminationTransitionDispatched = false;
 
         // Determine which question type for this round
         QuestionType questionType = GetQuestionTypeForRound(currentRound.Value);

--- a/Assets/Scripts/network_manager_script.cs
+++ b/Assets/Scripts/network_manager_script.cs
@@ -40,6 +40,7 @@ public class RWMNetworkManager : NetworkBehaviour
     public event Action<string> OnSceneChanged; // sceneName
     public event Action<float, bool> OnTimerSync; // timerValue, isActive
     public event Action OnConnectionError;
+    public event Action OnTransitionToElimination;
 
     private NetworkManager networkManager;
     private NetworkObject networkObject;
@@ -489,6 +490,42 @@ public class RWMNetworkManager : NetworkBehaviour
         {
             GameManager.Instance.SetPlayerScore(playerIdToUpdate, newScore);
         }
+    }
+
+    public void BroadcastTransitionToElimination()
+    {
+        if (!IsServer)
+        {
+            Debug.LogWarning("[RWMNetworkManager] Only the host server may broadcast elimination transitions.");
+            return;
+        }
+
+        Debug.Log("[RWMNetworkManager] Broadcasting transition-to-elimination signal.");
+        OnTransitionToElimination?.Invoke();
+
+        if (networkManager == null || !networkManager.IsListening)
+        {
+            return;
+        }
+
+        if (networkManager.ConnectedClientsIds.Count <= 1)
+        {
+            return;
+        }
+
+        TransitionToEliminationClientRpc();
+    }
+
+    [ClientRpc]
+    void TransitionToEliminationClientRpc()
+    {
+        if (isHost)
+        {
+            return;
+        }
+
+        Debug.Log("[RWMNetworkManager] Received transition-to-elimination signal from host.");
+        OnTransitionToElimination?.Invoke();
     }
 
     // === SCENE TRANSITIONS ===

--- a/Assets/Scripts/question_screen_script.cs
+++ b/Assets/Scripts/question_screen_script.cs
@@ -42,6 +42,9 @@ public class QuestionScreen : MonoBehaviour
     private string playerID = "";
     private List<GameObject> spawnedPlayerIcons = new List<GameObject>();
     private Coroutine errorCoroutine;
+    private bool hasRequestedEliminationTransition = false;
+    private bool isTransitioningToElimination = false;
+    private bool hasSubscribedToNetworkEvents = false;
     
     void Start()
     {
@@ -85,6 +88,12 @@ public class QuestionScreen : MonoBehaviour
             GameManager.Instance.QuestionUpdated += HandleQuestionUpdated;
             HandleQuestionUpdated(GameManager.Instance.GetCurrentQuestion());
         }
+
+        SubscribeToNetworkEvents();
+
+        // Reset transition guards each time the screen is shown
+        hasRequestedEliminationTransition = false;
+        isTransitioningToElimination = false;
     }
 
     void OnDisable()
@@ -93,10 +102,17 @@ public class QuestionScreen : MonoBehaviour
         {
             GameManager.Instance.QuestionUpdated -= HandleQuestionUpdated;
         }
+
+        UnsubscribeFromNetworkEvents();
     }
 
     void Update()
     {
+        if (!hasSubscribedToNetworkEvents)
+        {
+            SubscribeToNetworkEvents();
+        }
+
         // Update timer display
         UpdateTimerDisplay();
 
@@ -110,6 +126,40 @@ public class QuestionScreen : MonoBehaviour
         if (AudioManager.Instance != null && GameManager.Instance != null)
         {
             AudioManager.Instance.CheckTimerWarning(GameManager.Instance.GetTimeRemaining());
+        }
+    }
+
+    public void RequestTransitionToElimination()
+    {
+        if (hasRequestedEliminationTransition)
+        {
+            Debug.LogWarning("[QuestionScreen] Ignoring duplicate transition-to-elimination request.");
+            return;
+        }
+
+        if (IsNetworkActive())
+        {
+            if (!IsHostClient())
+            {
+                Debug.LogWarning("[QuestionScreen] Only the host may request the elimination transition when connected.");
+                return;
+            }
+
+            hasRequestedEliminationTransition = true;
+
+            if (GameManager.Instance != null)
+            {
+                GameManager.Instance.AdvanceToNextScreen();
+            }
+        }
+        else
+        {
+            BeginEliminationTransition();
+
+            if (GameManager.Instance != null)
+            {
+                GameManager.Instance.AdvanceToNextScreen();
+            }
         }
     }
 
@@ -644,5 +694,80 @@ public class QuestionScreen : MonoBehaviour
         {
             answerSubmitButton.onClick.RemoveListener(OnSubmitAnswer);
         }
+
+        UnsubscribeFromNetworkEvents();
+    }
+
+    void SubscribeToNetworkEvents()
+    {
+        if (hasSubscribedToNetworkEvents)
+        {
+            return;
+        }
+
+        if (RWMNetworkManager.Instance == null)
+        {
+            return;
+        }
+
+        RWMNetworkManager.Instance.OnTransitionToElimination += HandleTransitionToEliminationSignal;
+        hasSubscribedToNetworkEvents = true;
+    }
+
+    void UnsubscribeFromNetworkEvents()
+    {
+        if (!hasSubscribedToNetworkEvents)
+        {
+            return;
+        }
+
+        if (RWMNetworkManager.Instance != null)
+        {
+            RWMNetworkManager.Instance.OnTransitionToElimination -= HandleTransitionToEliminationSignal;
+        }
+
+        hasSubscribedToNetworkEvents = false;
+    }
+
+    void HandleTransitionToEliminationSignal()
+    {
+        BeginEliminationTransition();
+    }
+
+    void BeginEliminationTransition()
+    {
+        if (isTransitioningToElimination)
+        {
+            return;
+        }
+
+        isTransitioningToElimination = true;
+        hasRequestedEliminationTransition = true;
+
+        if (answerInput != null)
+        {
+            answerInput.interactable = false;
+        }
+
+        if (answerSubmitButton != null)
+        {
+            answerSubmitButton.interactable = false;
+        }
+
+        if (submissionConfirmationText != null)
+        {
+            submissionConfirmationText.gameObject.SetActive(true);
+            submissionConfirmationText.text = "Please wait...";
+        }
+    }
+
+    bool IsNetworkActive()
+    {
+        return RWMNetworkManager.Instance != null && RWMNetworkManager.Instance.isConnected;
+    }
+
+    bool IsHostClient()
+    {
+        return IsNetworkActive() && RWMNetworkManager.Instance.isHost;
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated elimination transition request path in the question screen that guards duplicate requests and waits for host broadcasts
- expose a host-only BroadcastTransitionToElimination event in the network manager so clients can subscribe to the authoritative signal
- gate GameManager scene changes on the new broadcast to avoid duplicate elimination transitions and reset the guard each round

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68ec21e549d0832ea7c38db440e251a6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Synchronized transition to the elimination phase across networked players, coordinated by the host.
  - Question screen now disables inputs and displays a “Please wait...” message during the transition.
- Bug Fixes
  - Prevents duplicate elimination transitions, ensuring the phase change is broadcast only once.
  - More reliable progression from question to elimination, aligned across all clients.
- Chores
  - Improved lifecycle handling for network event subscriptions to avoid missed or duplicated event handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->