### PR TITLE
Fix LoadingScreen NetworkManager conflict

### DIFF
--- a/Assets/Scenes/LoadingScreen.unity
+++ b/Assets/Scenes/LoadingScreen.unity
@@ -959,7 +959,6 @@ GameObject:
   - component: {fileID: 2108762729}
   - component: {fileID: 2108762728}
   - component: {fileID: 2108762735}
-  - component: {fileID: 2108762734}
   m_Layer: 0
   m_Name: Managers
   m_TagString: Untagged
@@ -1133,17 +1132,51 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bc1a65fc3a9553c4fbb182dd4e425fcd, type: 3}
   m_Name:
   m_EditorClassIdentifier:
+  networkManagerOverride: {fileID: 0}
+  unityTransportOverride: {fileID: 0}
   roomCode:
   isHost: 0
   port: 7777
   isConnected: 0
   playerId:
+--- !u!1 &1530942754
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1530942755}
+  - component: {fileID: 2108762734}
+  m_Layer: 0
+  m_Name: NetworkManagerSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1530942755
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1530942754}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2108762734
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2108762726}
+  m_GameObject: {fileID: 1530942754}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 593a2fe42fa9d37498c96f9a383b6521, type: 3}
@@ -1170,3 +1203,4 @@ SceneRoots:
   - {fileID: 756523228}
   - {fileID: 2098047015}
   - {fileID: 2108762727}
+  - {fileID: 1530942755}

--- a/Assets/Scripts/network_manager_script.cs
+++ b/Assets/Scripts/network_manager_script.cs
@@ -7,10 +7,17 @@ using Unity.Netcode.Transports.UTP;
 /// Unity Netcode-based NetworkManager for RWM multiplayer
 /// Desktop acts as Host (Server + Client), mobile devices connect as Clients
 /// </summary>
-[RequireComponent(typeof(NetworkManager), typeof(NetworkObject), typeof(UnityTransport))]
+[RequireComponent(typeof(NetworkObject))]
 public class RWMNetworkManager : NetworkBehaviour
 {
     public static RWMNetworkManager Instance;
+
+    [Header("Component References")]
+    [SerializeField]
+    private NetworkManager networkManagerOverride;
+
+    [SerializeField]
+    private UnityTransport unityTransportOverride;
 
     [Header("Network Settings")]
     public string roomCode = "";
@@ -72,7 +79,10 @@ public class RWMNetworkManager : NetworkBehaviour
             return;
         }
 
-        networkManager.NetworkConfig.NetworkTransport = unityTransport;
+        if (networkManager.NetworkConfig.NetworkTransport != unityTransport)
+        {
+            networkManager.NetworkConfig.NetworkTransport = unityTransport;
+        }
 
         // Load or generate player ID
         if (PlayerPrefs.HasKey("PlayerID"))
@@ -568,31 +578,67 @@ public class RWMNetworkManager : NetworkBehaviour
 
     private bool EnsureNetworkingComponents()
     {
-        networkManager = GetComponent<NetworkManager>();
-        networkObject = GetComponent<NetworkObject>();
-        unityTransport = GetComponent<UnityTransport>();
-
-        if (componentsValidated)
+        if (componentsValidated && networkManager != null && networkObject != null && unityTransport != null)
         {
-            return networkManager != null && networkObject != null && unityTransport != null;
+            return true;
         }
 
-        if (networkManager == null)
+        if (networkObject == null)
         {
-            Debug.LogError("[NetworkManager] NetworkManager component is missing. Please ensure the Managers object in LoadingScreen includes a configured NetworkManager component.");
-            return false;
+            networkObject = GetComponent<NetworkObject>();
         }
 
         if (networkObject == null)
         {
             networkObject = gameObject.AddComponent<NetworkObject>();
-            Debug.LogWarning("[NetworkManager] NetworkObject component was missing and has been added at runtime. Update the Managers object in LoadingScreen to include it to avoid runtime creation.");
+            Debug.LogWarning("[NetworkManager] NetworkObject component was missing and has been added at runtime to the RWMNetworkManager object. Update the LoadingScreen scene so the NetworkObject lives alongside this component to avoid runtime creation.");
+        }
+
+        if (networkManagerOverride != null)
+        {
+            networkManager = networkManagerOverride;
+        }
+
+        if (networkManager == null)
+        {
+            networkManager = NetworkManager.Singleton;
+        }
+
+        if (networkManager == null)
+        {
+            networkManager = GetComponent<NetworkManager>();
+        }
+
+        if (networkManager == null)
+        {
+            networkManager = FindObjectOfType<NetworkManager>();
+        }
+
+        if (networkManager == null)
+        {
+            Debug.LogError("[NetworkManager] NetworkManager component is missing from the scene. Please ensure a dedicated GameObject (for example, 'NetworkManagerSystem') contains the configured NetworkManager component in the LoadingScreen scene.");
+            return false;
+        }
+
+        if (unityTransportOverride != null)
+        {
+            unityTransport = unityTransportOverride;
         }
 
         if (unityTransport == null)
         {
-            unityTransport = gameObject.AddComponent<UnityTransport>();
-            Debug.LogWarning("[NetworkManager] UnityTransport component was missing and has been added at runtime with default settings. Configure the transport on the Managers object in LoadingScreen so remote clients can connect.");
+            unityTransport = networkManager.GetComponent<UnityTransport>();
+        }
+
+        if (unityTransport == null)
+        {
+            unityTransport = FindObjectOfType<UnityTransport>();
+        }
+
+        if (unityTransport == null)
+        {
+            unityTransport = networkManager.gameObject.AddComponent<UnityTransport>();
+            Debug.LogWarning("[NetworkManager] UnityTransport component was missing and has been added at runtime to the GameObject hosting the NetworkManager. Configure the transport on that object in LoadingScreen so remote clients can connect.");
         }
 
         componentsValidated = true;


### PR DESCRIPTION
## Summary
- move the Unity Netcode NetworkManager component to a dedicated NetworkManagerSystem root object in LoadingScreen
- update RWMNetworkManager to locate the NetworkManager/UnityTransport on external GameObjects and expose optional overrides
- add serialization entries for the new overrides so runtime warnings direct configuration in the scene

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ec4088613c832ebc8de1983a7ea7e1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime override options to manually select which networking and transport components to use, enabling flexible setup without changing public APIs.

* **Bug Fixes**
  * Improved startup resilience by auto-adding missing essential networking components with warnings.
  * Enhanced detection and reuse of existing components; avoids redundant transport reassignment.
  * Clearer warnings and errors when networking is misconfigured, reducing setup-related crashes and confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->